### PR TITLE
feat: integrate risk and treasury APIs

### DIFF
--- a/tests/test_profit_router.py
+++ b/tests/test_profit_router.py
@@ -17,7 +17,7 @@ def test_settle_triggers_sweep_and_scheduler(monkeypatch):
     # yesterday's PnL is positive
     yesterday = date.today() - timedelta(days=1)
 
-    def fake_pnl(day: date) -> float:
+    def fake_pnl(day: date, obs=None) -> float:
         assert day == yesterday
         return 100.0
 


### PR DESCRIPTION
## Summary
- replace risk and treasury stubs with authenticated API calls using retries and timeouts
- surface errors to Observability and propagate through sweep logic
- add tests mocking external responses and failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1307df4cc832db7bc8e57ccdc5387