### PR TITLE
Add walk-forward evaluation with calibration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pandas
 pandas-market-calendars
 numpy
+scikit-learn
 pyarrow
 fastparquet
 numba

--- a/src/quant_pipeline/walkforward.py
+++ b/src/quant_pipeline/walkforward.py
@@ -1,0 +1,100 @@
+"""Walk-forward evaluation with probability calibration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+from sklearn.calibration import CalibratedClassifierCV
+
+from .model_registry import ModelRegistry
+
+
+@dataclass
+class WalkforwardResult:
+    metrics: List[float]
+    stability: float
+
+
+def _calibrate(model, X: np.ndarray, y: np.ndarray, method: str) -> object:
+    calib = CalibratedClassifierCV(model, method=method, cv="prefit")
+    calib.fit(X, y)
+    return calib
+
+
+def _param_stability(params_hist: List[Dict[str, float]]) -> float:
+    if not params_hist:
+        return 0.0
+    keys = params_hist[0].keys()
+    vars_ = []
+    for k in keys:
+        vals = [p[k] for p in params_hist]
+        vars_.append(float(np.var(vals)))
+    return float(np.mean(vars_))
+
+
+def walkforward(
+    X: np.ndarray,
+    y: np.ndarray,
+    *,
+    train_window: int,
+    test_window: int,
+    step: int,
+    train_func: Callable[[np.ndarray, np.ndarray], Tuple[object, Dict[str, float]]],
+    metric_func: Callable[[np.ndarray, np.ndarray], float],
+    calibrate: Optional[str] = None,
+    registry: Optional[ModelRegistry] = None,
+    model_id: Optional[int] = None,
+) -> WalkforwardResult:
+    """Run walk-forward training/testing.
+
+    Parameters
+    ----------
+    X, y: np.ndarray
+        Full dataset features/labels ordered by time.
+    train_window, test_window: int
+        Number of samples for in-sample (IS) and out-of-sample (OOS) blocks.
+    step: int
+        Step size to advance the window.
+    train_func: Callable
+        Function returning (model, params) for provided training data.
+    metric_func: Callable
+        Computes metric given true labels and predicted probabilities.
+    calibrate: Optional[str]
+        Either 'sigmoid' for Platt scaling or 'isotonic'.
+    registry: ModelRegistry
+        Registry to log OOS metrics and parameters.
+    model_id: int
+        Identifier of model in registry.
+    """
+
+    metrics: List[float] = []
+    params_hist: List[Dict[str, float]] = []
+
+    n = len(X)
+    start = 0
+    while start + train_window + test_window <= n:
+        end_train = start + train_window
+        end_test = end_train + test_window
+        X_train, y_train = X[start:end_train], y[start:end_train]
+        X_test, y_test = X[end_train:end_test], y[end_train:end_test]
+
+        model, params = train_func(X_train, y_train)
+        if calibrate:
+            model = _calibrate(model, X_train, y_train, calibrate)
+
+        y_prob = model.predict_proba(X_test)[:, 1]
+        metric = metric_func(y_test, y_prob)
+        metrics.append(metric)
+        params_hist.append(params)
+
+        if registry and model_id is not None:
+            registry.log_oos_metrics(model_id, params=params, metrics={"metric": metric})
+
+        start += step
+
+    stability = _param_stability(params_hist)
+    return WalkforwardResult(metrics=metrics, stability=stability)
+
+
+__all__ = ["walkforward", "WalkforwardResult"]

--- a/tests/test_walkforward.py
+++ b/tests/test_walkforward.py
@@ -1,0 +1,47 @@
+import json
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from quant_pipeline.walkforward import walkforward
+from quant_pipeline.model_registry import ModelRegistry
+
+
+def test_walkforward_logs_oos_and_stability(tmp_path):
+    X, y = make_classification(n_samples=120, n_features=5, random_state=0)
+    reg = ModelRegistry(str(tmp_path / "reg.db"))
+    model_id = reg.register_model(
+        model_type="lr", genes_json="{}", artifact_path="a", calib_path="c"
+    )
+
+    def train_func(X_tr, y_tr):
+        model = LogisticRegression(max_iter=200).fit(X_tr, y_tr)
+        params = {"coef": float(model.coef_[0][0])}
+        return model, params
+
+    def metric_fn(y_true, y_prob):
+        preds = (y_prob > 0.5).astype(int)
+        return float((preds == y_true).mean())
+
+    result = walkforward(
+        X,
+        y,
+        train_window=60,
+        test_window=20,
+        step=20,
+        train_func=train_func,
+        metric_func=metric_fn,
+        calibrate="sigmoid",
+        registry=reg,
+        model_id=model_id,
+    )
+
+    assert len(result.metrics) == 3
+    assert result.stability >= 0.0
+
+    rows = reg.list_oos_metrics(model_id)
+    assert len(rows) == 3
+    first = rows[0]
+    params = json.loads(first["params_json"])
+    metrics = json.loads(first["metrics_json"])
+    assert "coef" in params
+    assert "metric" in metrics


### PR DESCRIPTION
## Summary
- support walk-forward IS→OOS training with optional Platt or isotonic calibration
- store out-of-sample metrics and parameters in ModelRegistry
- add scikit-learn dependency and accompanying tests

## Testing
- `pip install scikit-learn`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca8c094c832dadbf0f63f3cdf864