### PR TITLE
feat: enrich ingest and add purged kfold

### DIFF
--- a/tests/test_ingest_combine.py
+++ b/tests/test_ingest_combine.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from quant_pipeline.ingest import combine_market_data
+
+
+def test_combine_market_data_resample_and_adjustments():
+    base = 1_600_000_000_000
+    ohlcv = pd.DataFrame(
+        [
+            [base, 10, 11, 9, 10, 100],
+            [base + 30 * 60 * 1000, 11, 12, 10, 11, 150],
+        ],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    l2 = pd.DataFrame(
+        [[base, 1.0, 2.0], [base + 30 * 60 * 1000, 1.5, 2.5]],
+        columns=["timestamp", "bid", "ask"],
+    )
+    corporate = pd.DataFrame(
+        [[base + 15 * 60 * 1000, 2]], columns=["timestamp", "split_ratio"]
+    )
+    macro = pd.DataFrame(
+        [[base, 1], [base + 30 * 60 * 1000, 2]], columns=["timestamp", "macro"]
+    )
+
+    combined = combine_market_data(
+        ohlcv, l2=l2, corporate=corporate, macro=macro, tz="UTC", resample_rule="1h"
+    )
+
+    assert len(combined) == 1
+    row = combined.iloc[0]
+    assert row.open == 5  # adjusted for split
+    assert row.high == 12
+    assert row.low == 4.5
+    assert row.close == 11
+    assert row.volume == 250
+    assert row.bid == 1.25 and row.ask == 2.25
+    assert row.macro == 2

--- a/tests/test_purged_kfold.py
+++ b/tests/test_purged_kfold.py
@@ -1,0 +1,21 @@
+import numpy as np
+from quant_pipeline.training import PurgedKFold
+
+
+def test_purged_kfold_embargo():
+    pkf = PurgedKFold(n_splits=3, embargo=1)
+    X = np.arange(9)
+    splits = list(pkf.split(X))
+    assert len(splits) == 3
+
+    train0, test0 = splits[0]
+    assert np.array_equal(test0, np.array([0, 1, 2]))
+    assert np.array_equal(train0, np.array([4, 5, 6, 7, 8]))
+
+    train1, test1 = splits[1]
+    assert np.array_equal(test1, np.array([3, 4, 5]))
+    assert np.array_equal(train1, np.array([0, 1, 7, 8]))
+
+    train2, test2 = splits[2]
+    assert np.array_equal(test2, np.array([6, 7, 8]))
+    assert np.array_equal(train2, np.array([0, 1, 2, 3, 4]))


### PR DESCRIPTION
## Summary
- combine OHLCV with L2/L3, corporate actions and macro data with resampling, split/outlier adjustments and timezone support
- introduce PurgedKFold splitter with embargo to reduce leakage
- add unit tests for combined ingest and PurgedKFold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca825750832d85140872dc270e61