### PR TITLE
feat: enhance genetic optimiser and fitness

### DIFF
--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -7,10 +7,25 @@ from quant_pipeline.genetic import GeneticOptimizer
 
 def test_run_backtest_with_genes():
     df = pd.DataFrame({"ret": [0.01, -0.02, 0.03, -0.01]})
-    genes = [1, 16, 5, 0.001, 0.1, 1]
+    genes = [1, 16, 0.1, 5, 1, 0.001, 0.01]
     assert len(genes) == len(GENE_NAMES)
     pnl = run_backtest(df, genes, threshold=0.0, ema_alpha=0.5, cooldown=1)
     assert isinstance(pnl, float)
+
+
+def test_turnover_penalty():
+    df = pd.DataFrame({"ret": [0.01, -0.02, 0.03, -0.01]})
+    genes = [1, 16, 0.1, 5, 1, 0.001, 0.01]
+    pnl_raw = run_backtest(df, genes, threshold=0.0, ema_alpha=0.0, cooldown=0)
+    pnl_penalised = run_backtest(
+        df,
+        genes,
+        threshold=0.0,
+        ema_alpha=0.0,
+        cooldown=0,
+        turnover_penalty=1.0,
+    )
+    assert pnl_penalised <= pnl_raw
 
 
 def test_genetic_optimizer_vector_bounds():
@@ -19,7 +34,7 @@ def test_genetic_optimizer_vector_bounds():
 
     bounds = [(0, 1), (0, 1)]
     opt = GeneticOptimizer(fitness, bounds, population_size=20, rng=np.random.default_rng(0))
-    best, score = opt.optimise(generations=5)
+    best, score = opt.optimise(generations=5, patience=3)
     assert best.shape == (2,)
     assert 0 <= best[0] <= 1 and 0 <= best[1] <= 1
 


### PR DESCRIPTION
## Summary
- parameterize gene vector with LSTM layers, dropout, horizon, learning rate and weight decay
- add tournament selection, bounded crossover and successive-halving early stopping to the genetic optimiser
- support post-processing rules and turnover penalties in backtests

## Testing
- `pytest tests/test_genetic.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce7ae410832dafe7fbf0527a340e