### PR TITLE
feat: enhance backtester with costs and metrics

### DIFF
--- a/src/quant_pipeline/backtest.py
+++ b/src/quant_pipeline/backtest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
+import numpy as np
 import pandas as pd
 
 GENE_NAMES = [
@@ -78,7 +79,15 @@ def run_backtest(
     threshold: float = 0.0,
     ema_alpha: float = 0.0,
     cooldown: int = 0,
-) -> float:
+    spread_col: str | None = "spread",
+    volume_col: str | None = "volume",
+    volume_cost: float = 0.0,
+    slippage: float = 0.0,
+    order_latency: int = 0,
+    network_latency: int = 0,
+    return_metrics: bool = False,
+    rng: np.random.Generator | None = None,
+) -> float | dict[str, float]:
     """Run a simple backtest using optional gene parameters.
 
     Parameters
@@ -97,7 +106,9 @@ def run_backtest(
     Returns
     -------
     float
-        The cumulative return of the strategy after post-processing.
+        The cumulative return of the strategy after post-processing or,
+        when ``return_metrics`` is ``True``, a dictionary containing
+        ``pnl``, ``calmar``, ``max_drawdown`` and ``turnover``.
     """
 
     if "ret" not in df.columns:
@@ -117,8 +128,42 @@ def run_backtest(
     signal = _apply_postprocess(
         raw_signal, threshold=threshold, ema_alpha=ema_alpha, cooldown=cooldown
     )
-    pnl = (signal.shift().fillna(0) * df["ret"]).cumsum().iloc[-1]
-    return float(pnl)
+
+    # Simulate latency from order queues and network/broker delays.
+    total_latency = max(order_latency, 0) + max(network_latency, 0)
+    if total_latency > 0:
+        exec_signal = signal.shift(total_latency).fillna(0)
+    else:
+        exec_signal = signal
+
+    trades = exec_signal.diff().abs().fillna(exec_signal.abs())
+    spread = df[spread_col] if spread_col and spread_col in df.columns else 0
+    volume = df[volume_col] if volume_col and volume_col in df.columns else 1
+    cost = trades * (spread + volume_cost / volume)
+
+    if slippage > 0:
+        if rng is None:
+            rng = np.random.default_rng()
+        cost += np.abs(rng.normal(0.0, slippage, size=len(df))) * trades
+
+    strat_ret = exec_signal.shift().fillna(0) * df["ret"] - cost
+    pnl_series = strat_ret.cumsum()
+    pnl = pnl_series.iloc[-1] if not pnl_series.empty else 0.0
+
+    if not return_metrics:
+        return float(pnl)
+
+    dd = pnl_series.cummax() - pnl_series
+    max_dd = float(dd.max()) if not dd.empty else 0.0
+    calmar = float(pnl / max_dd) if max_dd != 0 else float("inf")
+    turnover = float(trades.sum())
+
+    return {
+        "pnl": float(pnl),
+        "calmar": calmar,
+        "max_drawdown": max_dd,
+        "turnover": turnover,
+    }
 
 
 __all__ = ["run_backtest", "GENE_NAMES"]

--- a/tests/test_backtest_enhancements.py
+++ b/tests/test_backtest_enhancements.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from quant_pipeline.backtest import run_backtest
+
+
+def test_run_backtest_returns_metrics():
+    df = pd.DataFrame(
+        {
+            "ret": [0.01, -0.02, 0.03, -0.01],
+            "spread": [0.001] * 4,
+            "volume": [100] * 4,
+        }
+    )
+    metrics = run_backtest(df, return_metrics=True)
+    assert {"pnl", "calmar", "max_drawdown", "turnover"} <= metrics.keys()
+
+
+def test_costs_reduce_pnl():
+    df = pd.DataFrame({"ret": [0.01, 0.02, -0.01, 0.005]})
+    base = run_backtest(df, return_metrics=True)["pnl"]
+    costly = run_backtest(df, return_metrics=True, volume_cost=1.0, slippage=0.0)["pnl"]
+    assert costly <= base


### PR DESCRIPTION
## Summary
- model trading costs via spread, volume impact and random slippage
- simulate execution latency from order queues and network delays
- expose strategy metrics including Calmar ratio, drawdown and turnover

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce7d9aec832db5da1ebbf64e9746