### PR TITLE
feat: track risk rule artifacts and GA metadata

### DIFF
--- a/src/quant_pipeline/model_registry.py
+++ b/src/quant_pipeline/model_registry.py
@@ -23,6 +23,7 @@ class ModelRecord:
     scaler_path: Optional[str]
     features_path: Optional[str]
     thresholds_path: Optional[str]
+    risk_rules_path: Optional[str]
     ga_version: Optional[str]
     seed: Optional[int]
     data_hash: Optional[str]
@@ -56,6 +57,7 @@ class ModelRegistry:
                 scaler_path TEXT,
                 features_path TEXT,
                 thresholds_path TEXT,
+                risk_rules_path TEXT,
                 ga_version TEXT,
                 seed INTEGER,
                 data_hash TEXT,
@@ -69,6 +71,7 @@ class ModelRegistry:
             ("scaler_path", "TEXT"),
             ("features_path", "TEXT"),
             ("thresholds_path", "TEXT"),
+            ("risk_rules_path", "TEXT"),
             ("ga_version", "TEXT"),
             ("seed", "INTEGER"),
             ("data_hash", "TEXT"),
@@ -113,6 +116,7 @@ class ModelRegistry:
         scaler_path: Optional[str] = None,
         features_path: Optional[str] = None,
         thresholds_path: Optional[str] = None,
+        risk_rules_path: Optional[str] = None,
         ga_version: Optional[str] = None,
         seed: Optional[int] = None,
         data_hash: Optional[str] = None,
@@ -125,9 +129,9 @@ class ModelRegistry:
             cur = self.conn.cursor()
             cur.execute(
                 """INSERT INTO models(ts, type, genes_json, artifact_path, calib_path,
-                lstm_path, scaler_path, features_path, thresholds_path,
+                lstm_path, scaler_path, features_path, thresholds_path, risk_rules_path,
                 ga_version, seed, data_hash, status)
-                VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     ts,
                     model_type,
@@ -138,6 +142,7 @@ class ModelRegistry:
                     scaler_path,
                     features_path,
                     thresholds_path,
+                    risk_rules_path,
                     ga_version,
                     seed,
                     data_hash,
@@ -313,6 +318,10 @@ class ModelRegistry:
         if model.get("thresholds_path"):
             thresh_dest = d / "current_thresholds"
             shutil.copyfile(model["thresholds_path"], thresh_dest)
+        risk_dest = None
+        if model.get("risk_rules_path"):
+            risk_dest = d / "current_risk_rules"
+            shutil.copyfile(model["risk_rules_path"], risk_dest)
         meta = {
             "id": model_id,
             "type": model["type"],
@@ -323,6 +332,7 @@ class ModelRegistry:
             "scaler": str(scaler_dest) if scaler_dest else None,
             "features": str(feat_dest) if feat_dest else None,
             "thresholds": str(thresh_dest) if thresh_dest else None,
+            "risk_rules": str(risk_dest) if risk_dest else None,
             "ga_version": model.get("ga_version"),
             "seed": model.get("seed"),
             "data_hash": model.get("data_hash"),

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -82,6 +82,14 @@ class AutoTrainer:
             genes_json=info.get("genes_json", "{}"),
             artifact_path=info["artifact_path"],
             calib_path=info["calib_path"],
+            lstm_path=info.get("lstm_path"),
+            scaler_path=info.get("scaler_path"),
+            features_path=info.get("features_path"),
+            thresholds_path=info.get("thresholds_path"),
+            risk_rules_path=info.get("risk_rules_path"),
+            ga_version=info.get("ga_version"),
+            seed=info.get("seed"),
+            data_hash=info.get("data_hash"),
             ts=int(time.time()),
         )
         logger.info("registered challenger %s for shadow eval", model_id)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -4,7 +4,7 @@ from quant_pipeline.model_registry import ChampionReloader, ModelRegistry
 
 def _mk_files(tmp_path, tag):
     files = {}
-    for suffix in ["bin", "calib", "lstm", "scaler", "feat", "thresh"]:
+    for suffix in ["bin", "calib", "lstm", "scaler", "feat", "thresh", "risk"]:
         p = tmp_path / f"{tag}.{suffix}"
         p.write_text(tag)
         files[suffix] = str(p)
@@ -26,6 +26,7 @@ def test_promotion_and_hot_reload(tmp_path):
         scaler_path=a_files["scaler"],
         features_path=a_files["feat"],
         thresholds_path=a_files["thresh"],
+        risk_rules_path=a_files["risk"],
         ga_version="v1",
         seed=1,
         data_hash="hash-a",
@@ -44,6 +45,7 @@ def test_promotion_and_hot_reload(tmp_path):
         scaler_path=b_files["scaler"],
         features_path=b_files["feat"],
         thresholds_path=b_files["thresh"],
+        risk_rules_path=b_files["risk"],
         ga_version="v1",
         seed=1,
         data_hash="hash-b",
@@ -63,10 +65,12 @@ def test_promotion_and_hot_reload(tmp_path):
     assert meta["ga_version"] == "v1"
     assert meta["seed"] == 1
     assert meta["data_hash"] == "hash-b"
+    assert meta["risk_rules"]
     assert (export / "current_lstm").read_text() == "b"
     assert (export / "current_scaler").read_text() == "b"
     assert (export / "current_features").read_text() == "b"
     assert (export / "current_thresholds").read_text() == "b"
+    assert (export / "current_risk_rules").read_text() == "b"
 
     loads = []
 
@@ -88,6 +92,7 @@ def test_promotion_and_hot_reload(tmp_path):
         scaler_path=c_files["scaler"],
         features_path=c_files["feat"],
         thresholds_path=c_files["thresh"],
+        risk_rules_path=c_files["risk"],
         ga_version="v1",
         seed=1,
         data_hash="hash-c",


### PR DESCRIPTION
## Summary
- extend model registry schema to include risk rule artifacts along with GA version, seed and dataset hash metadata
- export all artifacts when promoting a champion, including new risk rules file
- forward detailed training artifact paths and GA metadata when registering models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1ce7f2470832d9f1a3cb8bb5a85f8