### PR TITLE
Parallel challenger evaluation with drift monitoring and dashboards

### DIFF
--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,14 @@
+# Trading Dashboards
+
+The system exposes trading metrics via Prometheus to build dashboards for:
+
+- **PnL**
+- **Exposure**
+- **Hit-rate**
+- **Drawdown**
+- **Fills vs orders**
+- **Latencies**
+
+Use `trading.metrics.start_metrics_server` to start the HTTP endpoint and update the
+metrics during execution. Metrics can then be scraped by Prometheus and visualised
+in tools like Grafana.

--- a/src/quant_pipeline/drift.py
+++ b/src/quant_pipeline/drift.py
@@ -1,0 +1,59 @@
+"""Simple data/concept drift detection utilities."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DriftResult:
+    ks: float
+    psi: float
+
+
+class DriftDetector:
+    """Detects data drift using KS-test and Population Stability Index."""
+
+    def __init__(self, *, ks_threshold: float = 0.1, psi_threshold: float = 0.1, bins: int = 10) -> None:
+        self.ks_threshold = ks_threshold
+        self.psi_threshold = psi_threshold
+        self.bins = bins
+
+    # ------------------------------------------------------------------
+    def _ks_stat(self, ref: np.ndarray, cur: np.ndarray) -> float:
+        ref_sorted = np.sort(ref)
+        cur_sorted = np.sort(cur)
+        all_vals = np.concatenate([ref_sorted, cur_sorted])
+        cdf_ref = np.searchsorted(ref_sorted, all_vals, side="right") / len(ref_sorted)
+        cdf_cur = np.searchsorted(cur_sorted, all_vals, side="right") / len(cur_sorted)
+        return float(np.max(np.abs(cdf_ref - cdf_cur)))
+
+    def _psi(self, ref: np.ndarray, cur: np.ndarray) -> float:
+        quantiles = np.linspace(0, 100, self.bins + 1)
+        bins = np.percentile(ref, quantiles)
+        bins[0] = -np.inf
+        bins[-1] = np.inf
+        ref_hist, _ = np.histogram(ref, bins=bins)
+        cur_hist, _ = np.histogram(cur, bins=bins)
+        ref_pct = ref_hist / max(len(ref), 1)
+        cur_pct = cur_hist / max(len(cur), 1)
+        # avoid division by zero
+        mask = (ref_pct > 0) & (cur_pct > 0)
+        psi = np.sum((ref_pct[mask] - cur_pct[mask]) * np.log(ref_pct[mask] / cur_pct[mask]))
+        return float(psi)
+
+    # ------------------------------------------------------------------
+    def check(self, reference: np.ndarray, current: np.ndarray) -> DriftResult:
+        ks = self._ks_stat(reference, current)
+        psi = self._psi(reference, current)
+        if ks > self.ks_threshold or psi > self.psi_threshold:
+            logger.warning("data drift detected ks=%.3f psi=%.3f", ks, psi)
+        return DriftResult(ks=ks, psi=psi)
+
+
+__all__ = ["DriftDetector", "DriftResult"]

--- a/src/quant_pipeline/model_registry.py
+++ b/src/quant_pipeline/model_registry.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
+import numpy as np
+
 
 @dataclass
 class ModelRecord:
@@ -219,27 +221,61 @@ class ModelRegistry:
         uplift_min: float,
         min_bars_to_compare: int,
         export_dir: str,
+        sharpe_min: float,
+        max_drawdown: float,
     ) -> Optional[int]:
         """Evaluate challengers and promote if performance uplift achieved."""
 
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         with self._lock:
             champ = self._current_champion()
-            champ_perf = self._recent_perf(champ["id"], eval_window_bars) if champ else []
-            for challenger in self.list_models(status="challenger"):
-                chal_perf = self._recent_perf(challenger["id"], eval_window_bars)
-                bars = min(len(champ_perf), len(chal_perf))
-                if bars < min_bars_to_compare:
-                    continue
-                champ_ret = sum(p["ret"] for p in champ_perf[-bars:]) if champ_perf else 0.0
-                chal_ret = sum(p["ret"] for p in chal_perf[-bars:])
-                if champ_ret == 0:
-                    uplift = float("inf") if chal_ret > 0 else 0.0
-                else:
-                    uplift = (chal_ret - champ_ret) / abs(champ_ret)
-                if uplift >= uplift_min:
-                    self.promote_model(challenger["id"], export_dir)
-                    return challenger["id"]
+            champ_perf = (
+                self._recent_perf(champ["id"], eval_window_bars) if champ else []
+            )
+
+        champ_ret = sum(p["ret"] for p in champ_perf)
+
+        def _metrics(perf: List[Dict]) -> Dict[str, float]:
+            rets = [p["ret"] for p in perf]
+            sharpes = [p["sharpe"] for p in perf]
+            cum = np.cumsum(rets)
+            dd = float(np.max(np.maximum.accumulate(cum) - cum)) if len(cum) else 0.0
+            return {
+                "ret": sum(rets),
+                "sharpe": float(np.mean(sharpes)) if sharpes else 0.0,
+                "dd": dd,
+                "bars": len(perf),
+            }
+
+        challengers = self.list_models(status="challenger")
+
+        def _eval(chal: Dict) -> Optional[int]:
+            chal_perf = self._recent_perf(chal["id"], eval_window_bars)
+            metrics = _metrics(chal_perf)
+            bars = min(metrics["bars"], len(champ_perf))
+            if bars < min_bars_to_compare:
+                return None
+            if champ_ret == 0:
+                uplift = float("inf") if metrics["ret"] > 0 else 0.0
+            else:
+                uplift = (metrics["ret"] - champ_ret) / abs(champ_ret)
+            if (
+                uplift >= uplift_min
+                and metrics["sharpe"] >= sharpe_min
+                and metrics["dd"] <= max_drawdown
+            ):
+                self.promote_model(chal["id"], export_dir)
+                return chal["id"]
             return None
+
+        with ThreadPoolExecutor() as ex:
+            futures = {ex.submit(_eval, c): c for c in challengers}
+            for fut in as_completed(futures):
+                res = fut.result()
+                if res is not None:
+                    return res
+        return None
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -26,6 +26,7 @@ class AutoTrainer:
         max_challengers: int,
         build_dataset: Callable[[int], Any],
         train_model: Callable[[Any], Dict[str, str]],
+        num_parallel: int = 1,
     ) -> None:
         self.registry = registry
         self.train_every_bars = train_every_bars
@@ -33,6 +34,7 @@ class AutoTrainer:
         self.max_challengers = max_challengers
         self.build_dataset = build_dataset
         self.train_model = train_model
+        self.num_parallel = max(1, num_parallel)
         self._bar_count = 0
         self._event = threading.Event()
         self._stop = threading.Event()
@@ -73,18 +75,26 @@ class AutoTrainer:
     def _train_cycle(self) -> None:
         logger.info("training cycle started")
         dataset = self.build_dataset(self.history_days)
-        info = self.train_model(dataset)
-        if not info:
-            logger.warning("training produced no model")
-            return
-        model_id = self.registry.register_model(
-            model_type=info["type"],
-            genes_json=info.get("genes_json", "{}"),
-            artifact_path=info["artifact_path"],
-            calib_path=info["calib_path"],
-            ts=int(time.time()),
-        )
-        logger.info("registered challenger %s for shadow eval", model_id)
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _train() -> Dict[str, str]:
+            return self.train_model(dataset)
+
+        with ThreadPoolExecutor(max_workers=self.num_parallel) as ex:
+            futures = [ex.submit(_train) for _ in range(self.num_parallel)]
+            for fut in futures:
+                info = fut.result()
+                if not info:
+                    logger.warning("training produced no model")
+                    continue
+                model_id = self.registry.register_model(
+                    model_type=info["type"],
+                    genes_json=info.get("genes_json", "{}"),
+                    artifact_path=info["artifact_path"],
+                    calib_path=info["calib_path"],
+                    ts=int(time.time()),
+                )
+                logger.info("registered challenger %s for shadow eval", model_id)
         self.registry.prune_challengers(self.max_challengers)
 
 

--- a/src/trading/__init__.py
+++ b/src/trading/__init__.py
@@ -9,6 +9,16 @@ from .stable_allocator import (
     perform_sweep,
 )
 from . import ledger
+from .metrics import (
+    PNL,
+    EXPOSURE,
+    HIT_RATE,
+    DRAWDOWN,
+    FILLS,
+    ORDERS,
+    LATENCY,
+    start_metrics_server,
+)
 
 __all__ = [
     "load_stable_cfg",
@@ -21,4 +31,12 @@ __all__ = [
     "place_or_schedule",
     "perform_sweep",
     "ledger",
+    "PNL",
+    "EXPOSURE",
+    "HIT_RATE",
+    "DRAWDOWN",
+    "FILLS",
+    "ORDERS",
+    "LATENCY",
+    "start_metrics_server",
 ]

--- a/src/trading/metrics.py
+++ b/src/trading/metrics.py
@@ -1,0 +1,31 @@
+"""Prometheus metrics for trading dashboards."""
+
+from __future__ import annotations
+
+from prometheus_client import Gauge, Histogram, Counter, start_http_server
+
+PNL = Gauge("pnl", "Profit and Loss")
+EXPOSURE = Gauge("exposure", "Current market exposure")
+HIT_RATE = Gauge("hit_rate", "Trade hit rate")
+DRAWDOWN = Gauge("drawdown", "Max drawdown")
+FILLS = Counter("fills", "Number of order fills")
+ORDERS = Counter("orders", "Number of orders sent")
+LATENCY = Histogram("latency_seconds", "Order latency in seconds")
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start Prometheus metrics HTTP server."""
+
+    start_http_server(port)
+
+
+__all__ = [
+    "PNL",
+    "EXPOSURE",
+    "HIT_RATE",
+    "DRAWDOWN",
+    "FILLS",
+    "ORDERS",
+    "LATENCY",
+    "start_metrics_server",
+]

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -56,6 +56,8 @@ def test_promotion_and_hot_reload(tmp_path):
         uplift_min=0.5,
         min_bars_to_compare=3,
         export_dir=str(export),
+        sharpe_min=0.5,
+        max_drawdown=1.0,
     )
     assert promoted == challenger_id
     meta = json.loads((export / "current_meta.json").read_text())
@@ -100,6 +102,8 @@ def test_promotion_and_hot_reload(tmp_path):
         uplift_min=0.2,
         min_bars_to_compare=3,
         export_dir=str(export),
+        sharpe_min=0.5,
+        max_drawdown=1.0,
     )
     assert reloader.poll() == c_id
     assert loads == [challenger_id, c_id]


### PR DESCRIPTION
## Summary
- Train multiple challenger models concurrently via AutoTrainer
- Evaluate challengers in parallel and only promote those surpassing Sharpe and drawdown thresholds
- Add drift detection (KS-test, PSI) and Prometheus metrics for trading dashboards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce80f920832d87baa025eaad2e4d