### PR TITLE
Enhance model evaluation and monitoring

### DIFF
--- a/src/quant_pipeline/backtest.py
+++ b/src/quant_pipeline/backtest.py
@@ -80,10 +80,7 @@ def run_backtest(
     threshold: float = 0.0,
     ema_alpha: float = 0.0,
     cooldown: int = 0,
-
     turnover_penalty: float = 0.0,
-) -> float:
-=======
     spread_col: str | None = "spread",
     volume_col: str | None = "volume",
     volume_cost: float = 0.0,
@@ -136,13 +133,6 @@ def run_backtest(
     signal = _apply_postprocess(
         raw_signal, threshold=threshold, ema_alpha=ema_alpha, cooldown=cooldown
     )
-    pnl = (signal.shift().fillna(0) * df["ret"]).cumsum().iloc[-1]
-    if turnover_penalty > 0:
-        turns = (signal != signal.shift()).sum()
-        pnl -= turnover_penalty * float(turns)
-    return float(pnl)
-=======
-
     # Simulate latency from order queues and network/broker delays.
     total_latency = max(order_latency, 0) + max(network_latency, 0)
     if total_latency > 0:
@@ -163,6 +153,10 @@ def run_backtest(
     strat_ret = exec_signal.shift().fillna(0) * df["ret"] - cost
     pnl_series = strat_ret.cumsum()
     pnl = pnl_series.iloc[-1] if not pnl_series.empty else 0.0
+
+    if turnover_penalty > 0:
+        turns = (exec_signal != exec_signal.shift()).sum()
+        pnl -= turnover_penalty * float(turns)
 
     if not return_metrics:
         return float(pnl)

--- a/src/quant_pipeline/model_registry.py
+++ b/src/quant_pipeline/model_registry.py
@@ -239,8 +239,6 @@ class ModelRegistry:
                 self._recent_perf(champ["id"], eval_window_bars) if champ else []
             )
 
-        champ_ret = sum(p["ret"] for p in champ_perf)
-
         def _metrics(perf: List[Dict]) -> Dict[str, float]:
             rets = [p["ret"] for p in perf]
             sharpes = [p["sharpe"] for p in perf]
@@ -252,6 +250,14 @@ class ModelRegistry:
                 "dd": dd,
                 "bars": len(perf),
             }
+
+        champ_metrics = _metrics(champ_perf) if champ_perf else {
+            "ret": 0.0,
+            "sharpe": float("-inf"),
+            "dd": float("inf"),
+            "bars": 0,
+        }
+        champ_ret = champ_metrics["ret"]
 
         challengers = self.list_models(status="challenger")
 
@@ -269,6 +275,13 @@ class ModelRegistry:
                 uplift >= uplift_min
                 and metrics["sharpe"] >= sharpe_min
                 and metrics["dd"] <= max_drawdown
+                and (
+                    not champ_perf
+                    or (
+                        metrics["sharpe"] > champ_metrics["sharpe"]
+                        and metrics["dd"] < champ_metrics["dd"]
+                    )
+                )
             ):
                 self.promote_model(chal["id"], export_dir)
                 return chal["id"]

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -76,27 +76,6 @@ class AutoTrainer:
         logger.info("training cycle started")
         dataset = self.build_dataset(self.history_days)
 
-        info = self.train_model(dataset)
-        if not info:
-            logger.warning("training produced no model")
-            return
-        model_id = self.registry.register_model(
-            model_type=info["type"],
-            genes_json=info.get("genes_json", "{}"),
-            artifact_path=info["artifact_path"],
-            calib_path=info["calib_path"],
-            lstm_path=info.get("lstm_path"),
-            scaler_path=info.get("scaler_path"),
-            features_path=info.get("features_path"),
-            thresholds_path=info.get("thresholds_path"),
-            risk_rules_path=info.get("risk_rules_path"),
-            ga_version=info.get("ga_version"),
-            seed=info.get("seed"),
-            data_hash=info.get("data_hash"),
-            ts=int(time.time()),
-        )
-        logger.info("registered challenger %s for shadow eval", model_id)
-=======
         from concurrent.futures import ThreadPoolExecutor
 
         def _train() -> Dict[str, str]:
@@ -114,6 +93,14 @@ class AutoTrainer:
                     genes_json=info.get("genes_json", "{}"),
                     artifact_path=info["artifact_path"],
                     calib_path=info["calib_path"],
+                    lstm_path=info.get("lstm_path"),
+                    scaler_path=info.get("scaler_path"),
+                    features_path=info.get("features_path"),
+                    thresholds_path=info.get("thresholds_path"),
+                    risk_rules_path=info.get("risk_rules_path"),
+                    ga_version=info.get("ga_version"),
+                    seed=info.get("seed"),
+                    data_hash=info.get("data_hash"),
                     ts=int(time.time()),
                 )
                 logger.info("registered challenger %s for shadow eval", model_id)

--- a/src/trading/metrics.py
+++ b/src/trading/metrics.py
@@ -11,6 +11,7 @@ DRAWDOWN = Gauge("drawdown", "Max drawdown")
 FILLS = Counter("fills", "Number of order fills")
 ORDERS = Counter("orders", "Number of orders sent")
 LATENCY = Histogram("latency_seconds", "Order latency in seconds")
+ORDER_QUEUE = Gauge("order_queue", "Current length of the order queue")
 
 
 def start_metrics_server(port: int = 8000) -> None:
@@ -27,5 +28,6 @@ __all__ = [
     "FILLS",
     "ORDERS",
     "LATENCY",
+    "ORDER_QUEUE",
     "start_metrics_server",
 ]

--- a/tests/test_drift_detector.py
+++ b/tests/test_drift_detector.py
@@ -1,0 +1,17 @@
+import numpy as np
+from quant_pipeline.drift import DriftDetector
+
+
+def test_drift_detector(caplog):
+    ref = np.linspace(0, 1, 100)
+    cur_same = ref.copy()
+    detector = DriftDetector(ks_threshold=0.1, psi_threshold=0.1)
+    res = detector.check(ref, cur_same)
+    assert res.ks == 0.0
+    assert res.psi == 0.0
+
+    cur_shift = ref + 1.0
+    with caplog.at_level("WARNING"):
+        res2 = detector.check(ref, cur_shift)
+    assert res2.ks > detector.ks_threshold or res2.psi > detector.psi_threshold
+    assert "data drift detected" in caplog.text

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -1,0 +1,6 @@
+from trading import metrics
+
+
+def test_order_queue_gauge():
+    metrics.ORDER_QUEUE.set(7)
+    assert metrics.ORDER_QUEUE._value.get() == 7

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -32,8 +32,9 @@ def test_promotion_and_hot_reload(tmp_path):
         data_hash="hash-a",
         status="champion",
     )
-    for i in range(5):
-        reg.log_perf(champ_id, ret=0.01, sharpe=1.0, ts=i)
+    champ_rets = [0.01, -0.05, 0.01, 0.01, 0.01]
+    for i, r in enumerate(champ_rets):
+        reg.log_perf(champ_id, ret=r, sharpe=0.5, ts=i)
 
     b_files = _mk_files(tmp_path, "b")
     challenger_id = reg.register_model(
@@ -50,8 +51,9 @@ def test_promotion_and_hot_reload(tmp_path):
         seed=1,
         data_hash="hash-b",
     )
-    for i in range(5):
-        reg.log_perf(challenger_id, ret=0.02, sharpe=1.0, ts=i)
+    b_rets = [0.02, 0.02, -0.02, 0.02, 0.02]
+    for i, r in enumerate(b_rets):
+        reg.log_perf(challenger_id, ret=r, sharpe=1.0, ts=i)
 
     promoted = reg.evaluate_challengers(
         eval_window_bars=5,
@@ -99,8 +101,9 @@ def test_promotion_and_hot_reload(tmp_path):
         seed=1,
         data_hash="hash-c",
     )
-    for i in range(5):
-        reg.log_perf(c_id, ret=0.03, sharpe=1.0, ts=i)
+    c_rets = [0.03, 0.03, -0.01, 0.03, 0.03]
+    for i, r in enumerate(c_rets):
+        reg.log_perf(c_id, ret=r, sharpe=1.5, ts=i)
 
     reg.evaluate_challengers(
         eval_window_bars=5,

--- a/tests/test_observability_alerts.py
+++ b/tests/test_observability_alerts.py
@@ -1,0 +1,15 @@
+from quant_pipeline.observability import Observability
+
+
+def test_observability_alerts(monkeypatch):
+    obs = Observability()
+    alerts = []
+    monkeypatch.setattr(obs, "_send_alert", lambda msg: alerts.append(msg))
+
+    obs.observe_sharpe(0.4, threshold=0.5)
+    obs.observe_slippage(12.0, threshold=10.0)
+    obs.observe_latency(120.0, threshold=100.0)
+
+    assert any("Sharpe" in a for a in alerts)
+    assert any("Slippage" in a for a in alerts)
+    assert any("Latency" in a for a in alerts)


### PR DESCRIPTION
## Summary
- Run challenger evaluations in parallel and require Sharpe ratio improvement with lower drawdown to promote models
- Add drift detection tests and alerts for Sharpe drops or elevated slippage/latency
- Expose order queue metric for dashboards

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d3fb2724832da58bd4e3117580c2