### PR TITLE
Add latency-aware backtest costs and metrics

### DIFF
--- a/src/quant_pipeline/backtest.py
+++ b/src/quant_pipeline/backtest.py
@@ -80,10 +80,7 @@ def run_backtest(
     threshold: float = 0.0,
     ema_alpha: float = 0.0,
     cooldown: int = 0,
-
     turnover_penalty: float = 0.0,
-) -> float:
-=======
     spread_col: str | None = "spread",
     volume_col: str | None = "volume",
     volume_cost: float = 0.0,
@@ -93,13 +90,13 @@ def run_backtest(
     return_metrics: bool = False,
     rng: np.random.Generator | None = None,
 ) -> float | dict[str, float]:
-
     """Run a simple backtest using optional gene parameters.
 
     Parameters
     ----------
     df:
-        Must contain a ``ret`` column representing returns.
+        Must contain a ``ret`` column representing returns. Optionally ``spread``
+        and ``volume`` columns are used for trading costs.
     genes:
         Sequence of seven values representing ``n_layers``, ``hidden_size``,
         ``dropout``, ``seq_len``, forecast horizon ``horizon``, learning rate
@@ -110,13 +107,29 @@ def run_backtest(
         fitness of a gene vector.
     turnover_penalty:
         Penalty applied per position change to discourage excessive turnover.
+    spread_col, volume_col:
+        Column names in ``df`` providing bid-ask spread and volume information.
+        If absent or ``None`` the respective component is ignored.
+    volume_cost:
+        Coefficient for volume based cost applied as ``volume_cost / volume``.
+    slippage:
+        Standard deviation of the normal distribution used to sample stochastic
+        slippage per trade (in return units).
+    order_latency, network_latency:
+        Number of bars of delay introduced by exchange queues and
+        network/broker latency respectively.
+    return_metrics:
+        When ``True`` return a dictionary with ``pnl``, ``calmar``,
+        ``max_drawdown`` and ``turnover`` instead of only the final pnl.
+    rng:
+        Optional random number generator used for slippage simulation.
 
     Returns
     -------
-    float
+    float | dict[str, float]
         The cumulative return of the strategy after post-processing or,
-        when ``return_metrics`` is ``True``, a dictionary containing
-        ``pnl``, ``calmar``, ``max_drawdown`` and ``turnover``.
+        when ``return_metrics`` is ``True``, a dictionary containing ``pnl``,
+        ``calmar``, ``max_drawdown`` and ``turnover``.
     """
 
     if "ret" not in df.columns:
@@ -136,12 +149,6 @@ def run_backtest(
     signal = _apply_postprocess(
         raw_signal, threshold=threshold, ema_alpha=ema_alpha, cooldown=cooldown
     )
-    pnl = (signal.shift().fillna(0) * df["ret"]).cumsum().iloc[-1]
-    if turnover_penalty > 0:
-        turns = (signal != signal.shift()).sum()
-        pnl -= turnover_penalty * float(turns)
-    return float(pnl)
-=======
 
     # Simulate latency from order queues and network/broker delays.
     total_latency = max(order_latency, 0) + max(network_latency, 0)
@@ -163,6 +170,10 @@ def run_backtest(
     strat_ret = exec_signal.shift().fillna(0) * df["ret"] - cost
     pnl_series = strat_ret.cumsum()
     pnl = pnl_series.iloc[-1] if not pnl_series.empty else 0.0
+
+    if turnover_penalty > 0:
+        turns = (exec_signal != exec_signal.shift()).sum()
+        pnl -= turnover_penalty * float(turns)
 
     if not return_metrics:
         return float(pnl)

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -76,27 +76,6 @@ class AutoTrainer:
         logger.info("training cycle started")
         dataset = self.build_dataset(self.history_days)
 
-        info = self.train_model(dataset)
-        if not info:
-            logger.warning("training produced no model")
-            return
-        model_id = self.registry.register_model(
-            model_type=info["type"],
-            genes_json=info.get("genes_json", "{}"),
-            artifact_path=info["artifact_path"],
-            calib_path=info["calib_path"],
-            lstm_path=info.get("lstm_path"),
-            scaler_path=info.get("scaler_path"),
-            features_path=info.get("features_path"),
-            thresholds_path=info.get("thresholds_path"),
-            risk_rules_path=info.get("risk_rules_path"),
-            ga_version=info.get("ga_version"),
-            seed=info.get("seed"),
-            data_hash=info.get("data_hash"),
-            ts=int(time.time()),
-        )
-        logger.info("registered challenger %s for shadow eval", model_id)
-=======
         from concurrent.futures import ThreadPoolExecutor
 
         def _train() -> Dict[str, str]:
@@ -114,6 +93,14 @@ class AutoTrainer:
                     genes_json=info.get("genes_json", "{}"),
                     artifact_path=info["artifact_path"],
                     calib_path=info["calib_path"],
+                    lstm_path=info.get("lstm_path"),
+                    scaler_path=info.get("scaler_path"),
+                    features_path=info.get("features_path"),
+                    thresholds_path=info.get("thresholds_path"),
+                    risk_rules_path=info.get("risk_rules_path"),
+                    ga_version=info.get("ga_version"),
+                    seed=info.get("seed"),
+                    data_hash=info.get("data_hash"),
                     ts=int(time.time()),
                 )
                 logger.info("registered challenger %s for shadow eval", model_id)


### PR DESCRIPTION
## Summary
- Extend `run_backtest` with spread, volume, and stochastic slippage costs
- Simulate order queue and network latency in backtests
- Return advanced metrics like Calmar ratio, drawdown, and turnover
- Restore parallel challenger training and pruning in `AutoTrainer`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d3ff1764832d9105f553e5bfcb6e