### PR TITLE
Add news sentiment connector and features

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -24,6 +24,15 @@ Partitioning: `lake/{exchange}/{symbol}/{timeframe}/YYYY/MM/DD.parquet`
 
 Partitioning: same as raw OHLCV.
 
+## News Sentiment Signals
+| Column    | Type  | Description                                      |
+|-----------|-------|--------------------------------------------------|
+| timestamp | int64 | milliseconds since Unix epoch UTC                |
+| symbol    | string| instrument symbol                                |
+| sentiment | float | normalized news sentiment score in [-1, 1]       |
+
+Partitioning: `lake/news/{symbol}/YYYY/MM/DD.parquet`
+
 ## Model Registry (SQLite)
 ### models
 | Column       | Type    | Description                           |

--- a/src/quant_pipeline/features.py
+++ b/src/quant_pipeline/features.py
@@ -58,8 +58,10 @@ class FeatureBuilder:
     """Stateful feature builder operating on streaming bars.
 
     The builder keeps track of the previous close to compute returns for new
-    bars on the fly. Each call to :meth:`update` returns a dataframe with the
-    freshly created features for the provided bar.
+    bars on the fly. Additional numeric fields present in the input ``bar``
+    (e.g. news ``sentiment`` scores) are forwarded unchanged. Each call to
+    :meth:`update` returns a dataframe with the freshly created features for
+    the provided bar.
     """
 
     def __init__(self) -> None:
@@ -70,7 +72,11 @@ class FeatureBuilder:
         ts = int(bar["timestamp"])
         ret = 0.0 if self._last_close is None else close / self._last_close - 1.0
         self._last_close = close
-        return pd.DataFrame([{ "timestamp": ts, "ret": ret }])
+        out = {"timestamp": ts, "ret": ret}
+        for key, val in bar.items():
+            if key not in {"timestamp", "close"}:
+                out[key] = val
+        return pd.DataFrame([out])
 
 
 class Scaler:

--- a/tests/test_features_scaler.py
+++ b/tests/test_features_scaler.py
@@ -4,14 +4,16 @@ from quant_pipeline.features import FeatureBuilder, Scaler
 def test_feature_builder_and_scaler_stateful():
     fb = FeatureBuilder()
     sc = Scaler()
-    bar1 = {"timestamp": 1, "close": 100.0}
+    bar1 = {"timestamp": 1, "close": 100.0, "sentiment": 0.1}
     f1 = fb.update(bar1)
+    assert f1["sentiment"].iloc[0] == 0.1
     scaled1 = sc.transform(f1[["ret"]])
     sc.update(f1[["ret"]])
     assert scaled1["ret"].iloc[0] == 0.0
 
-    bar2 = {"timestamp": 2, "close": 101.0}
+    bar2 = {"timestamp": 2, "close": 101.0, "sentiment": -0.2}
     f2 = fb.update(bar2)
+    assert f2["sentiment"].iloc[0] == -0.2
     scaled2 = sc.transform(f2[["ret"]])
     sc.update(f2[["ret"]])
     assert f2["ret"].iloc[0] != 0.0

--- a/tests/test_ingest_combine.py
+++ b/tests/test_ingest_combine.py
@@ -21,9 +21,19 @@ def test_combine_market_data_resample_and_adjustments():
     macro = pd.DataFrame(
         [[base, 1], [base + 30 * 60 * 1000, 2]], columns=["timestamp", "macro"]
     )
+    news = pd.DataFrame(
+        [[base, 0.1], [base + 30 * 60 * 1000, -0.2]],
+        columns=["timestamp", "sentiment"],
+    )
 
     combined = combine_market_data(
-        ohlcv, l2=l2, corporate=corporate, macro=macro, tz="UTC", resample_rule="1h"
+        ohlcv,
+        l2=l2,
+        corporate=corporate,
+        macro=macro,
+        news=news,
+        tz="UTC",
+        resample_rule="1h",
     )
 
     assert len(combined) == 1
@@ -35,3 +45,4 @@ def test_combine_market_data_resample_and_adjustments():
     assert row.volume == 250
     assert row.bid == 1.25 and row.ask == 2.25
     assert row.macro == 2
+    assert row.sentiment == -0.2


### PR DESCRIPTION
## Summary
- add `fetch_news_sentiment` connector and merge news signals in `combine_market_data`
- document news sentiment table contract and forward optional sentiment in FeatureBuilder
- expand tests for news sentiment integration

## Testing
- `pytest -q` *(fails: SyntaxError in quant_pipeline.training)*
- `pytest tests/test_ingest_combine.py tests/test_features_scaler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dda91f74832da15ec3508c11823f