### PR TITLE
Use SQLite-backed ledger and track order intents

### DIFF
--- a/src/trading/brokers/mock.py
+++ b/src/trading/brokers/mock.py
@@ -15,22 +15,51 @@ def _check(usd: float) -> None:
         raise ValueError("notional below minNotional")
 
 
-def place_market_on_open(ticker: str, usd: float) -> Tuple[str, str]:
+def _intent(ticker: str, usd: float, day, intent_id: str | None) -> str:
+    return intent_id or ledger.record_intent(ticker, usd, day=day)
+
+
+def place_market_on_open(
+    ticker: str,
+    usd: float,
+    obs=None,
+    *,
+    day=None,
+    intent_id: str | None = None,
+) -> Tuple[str, str]:
     _check(usd)
+    intent_id = _intent(ticker, usd, day, intent_id)
     order_id = f"mock-{uuid.uuid4().hex[:8]}"
-    ledger.record(order_id, ticker, usd, "filled")
+    ledger.record_result(intent_id, order_id, "filled", day=day)
     return order_id, "filled"
 
 
-def place_twap(ticker: str, usd: float, minutes: int = 30) -> Tuple[str, str]:
+def place_twap(
+    ticker: str,
+    usd: float,
+    minutes: int = 30,
+    obs=None,
+    *,
+    day=None,
+    intent_id: str | None = None,
+) -> Tuple[str, str]:
     _check(usd)
+    intent_id = _intent(ticker, usd, day, intent_id)
     order_id = f"mock-twap-{uuid.uuid4().hex[:8]}"
-    ledger.record(order_id, ticker, usd, "filled")
+    ledger.record_result(intent_id, order_id, "filled", day=day)
     return order_id, "filled"
 
 
-def place_limit_vwap(ticker: str, usd: float) -> Tuple[str, str]:
+def place_limit_vwap(
+    ticker: str,
+    usd: float,
+    obs=None,
+    *,
+    day=None,
+    intent_id: str | None = None,
+) -> Tuple[str, str]:
     _check(usd)
+    intent_id = _intent(ticker, usd, day, intent_id)
     order_id = f"mock-lvwap-{uuid.uuid4().hex[:8]}"
-    ledger.record(order_id, ticker, usd, "filled")
+    ledger.record_result(intent_id, order_id, "filled", day=day)
     return order_id, "filled"

--- a/src/trading/ledger.py
+++ b/src/trading/ledger.py
@@ -1,13 +1,29 @@
+"""Append-only order ledger backed by SQLite.
+
+This module replaces the previous in-memory list with a lightweight SQLite
+database so that order intents and outcomes are durably persisted.  Each order
+is stored as a pair of events: an ``intent`` recorded *before* the broker call
+and a subsequent result such as ``filled`` or ``error``.  Additional utility
+functions are provided to replay unreconciled intents or inspect the full
+ledger for auditing purposes.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import List, Optional
+import sqlite3
+import uuid
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+DB_PATH = Path("data/ledger.db")
 
 
 @dataclass
 class LedgerEntry:
-    order_id: str
+    intent_id: str
+    order_id: str | None
     ticker: str
     usd: float
     status: str
@@ -16,7 +32,49 @@ class LedgerEntry:
     scheduled_at: datetime | None = None
 
 
-entries: List[LedgerEntry] = []
+_conn: sqlite3.Connection | None = None
+
+
+def _connection() -> sqlite3.Connection:
+    """Return a SQLite connection, creating tables on first use."""
+
+    global _conn
+    if _conn is None:
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(DB_PATH)
+        _conn.row_factory = sqlite3.Row
+        _conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                intent_id TEXT NOT NULL,
+                order_id TEXT,
+                ticker TEXT NOT NULL,
+                usd REAL NOT NULL,
+                status TEXT NOT NULL,
+                day TEXT NOT NULL,
+                note TEXT,
+                scheduled_at TEXT,
+                ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        _conn.commit()
+    return _conn
+
+
+def _row_to_entry(row: sqlite3.Row) -> LedgerEntry:
+    scheduled = datetime.fromisoformat(row["scheduled_at"]) if row["scheduled_at"] else None
+    return LedgerEntry(
+        intent_id=row["intent_id"],
+        order_id=row["order_id"],
+        ticker=row["ticker"],
+        usd=float(row["usd"]),
+        status=row["status"],
+        date=date.fromisoformat(row["day"]),
+        note=row["note"],
+        scheduled_at=scheduled,
+    )
 
 
 def record(
@@ -28,30 +86,139 @@ def record(
     note: str | None = None,
     scheduled_at: datetime | None = None,
 ) -> None:
-    """Record a ledger entry.
+    """Record a generic ledger entry without an explicit intent.
 
-    Parameters
-    ----------
-    order_id: str
-        Broker-provided identifier.
-    ticker: str
-        Instrument ticker.
-    usd: float
-        Notional in USD.
-    status: str
-        Fill status.
-    day: date, optional
-        Settlement date. Defaults to current UTC date.
-    note: str, optional
-        Additional commentary about the entry.
-    scheduled_at: datetime, optional
-        Planned execution time for unsent orders.
+    This is used for events such as sweep blocks where no broker order is
+    attempted.  A fresh ``intent_id`` is generated automatically.
     """
 
     if day is None:
         day = datetime.utcnow().date()
-    entries.append(LedgerEntry(order_id, ticker, usd, status, day, note, scheduled_at))
+    conn = _connection()
+    conn.execute(
+        """
+        INSERT INTO ledger(intent_id, order_id, ticker, usd, status, day, note, scheduled_at)
+        VALUES(?,?,?,?,?,?,?,?)
+        """,
+        (
+            uuid.uuid4().hex,
+            order_id,
+            ticker,
+            usd,
+            status,
+            day.isoformat(),
+            note,
+            scheduled_at.isoformat() if scheduled_at else None,
+        ),
+    )
+    conn.commit()
+
+
+def record_intent(
+    ticker: str,
+    usd: float,
+    *,
+    day: Optional[date] = None,
+    note: str | None = None,
+    scheduled_at: datetime | None = None,
+    status: str = "intent",
+) -> str:
+    """Record an order intent and return its identifier."""
+
+    if day is None:
+        day = datetime.utcnow().date()
+    intent_id = uuid.uuid4().hex
+    conn = _connection()
+    conn.execute(
+        """
+        INSERT INTO ledger(intent_id, order_id, ticker, usd, status, day, note, scheduled_at)
+        VALUES(?,?,?,?,?,?,?,?)
+        """,
+        (
+            intent_id,
+            None,
+            ticker,
+            usd,
+            status,
+            day.isoformat(),
+            note,
+            scheduled_at.isoformat() if scheduled_at else None,
+        ),
+    )
+    conn.commit()
+    return intent_id
+
+
+def record_result(
+    intent_id: str,
+    order_id: str,
+    status: str,
+    *,
+    day: Optional[date] = None,
+    note: str | None = None,
+) -> None:
+    """Append a result entry for a previously recorded intent."""
+
+    if day is None:
+        day = datetime.utcnow().date()
+    conn = _connection()
+    conn.execute(
+        """
+        INSERT INTO ledger(intent_id, order_id, ticker, usd, status, day, note, scheduled_at)
+        SELECT ?, ?, ticker, usd, ?, ?, ?, scheduled_at FROM ledger
+        WHERE intent_id = ? AND status IN ('intent', 'planned')
+        LIMIT 1
+        """,
+        (
+            intent_id,
+            order_id,
+            status,
+            day.isoformat(),
+            note,
+            intent_id,
+        ),
+    )
+    conn.commit()
+
+
+def entries() -> List[LedgerEntry]:
+    """Return all ledger entries in insertion order."""
+
+    conn = _connection()
+    rows = conn.execute("SELECT intent_id, order_id, ticker, usd, status, day, note, scheduled_at FROM ledger ORDER BY id").fetchall()
+    return [_row_to_entry(r) for r in rows]
+
+
+def pending(status: str = "planned") -> List[LedgerEntry]:
+    """Return intents with the given status lacking a corresponding result."""
+
+    conn = _connection()
+    rows = conn.execute(
+        """
+        SELECT intent_id, order_id, ticker, usd, status, day, note, scheduled_at
+        FROM ledger AS l
+        WHERE status = ?
+          AND intent_id NOT IN (
+                SELECT intent_id FROM ledger WHERE status NOT IN ('intent', 'planned')
+            )
+        ORDER BY id
+        """,
+        (status,),
+    ).fetchall()
+    return [_row_to_entry(r) for r in rows]
+
+
+def replay() -> Iterable[LedgerEntry]:
+    """Yield ledger entries in chronological order for reconstruction."""
+
+    for entry in entries():
+        yield entry
 
 
 def clear() -> None:
-    entries.clear()
+    """Remove all ledger entries (primarily for tests)."""
+
+    conn = _connection()
+    conn.execute("DELETE FROM ledger")
+    conn.commit()
+

--- a/tests/test_broker_sdks.py
+++ b/tests/test_broker_sdks.py
@@ -45,7 +45,7 @@ def test_rate_limit(monkeypatch, broker, client_attr):
         monkeypatch.setattr(broker, client_attr, lambda: _IBClient(raise_error=True))
     with pytest.raises(Exception):
         broker.place_market_on_open("SPY", 100, obs)
-    assert ledger.entries[0].status == "error"
+    assert ledger.entries()[-1].status == "error"
     assert obs.order_errors_total._value.get() == 1
 
 
@@ -62,6 +62,7 @@ def test_cancelled(monkeypatch, broker, client_attr, cancel_status):
         monkeypatch.setattr(broker, client_attr, lambda: _IBClient(status=cancel_status))
     oid, status = broker.place_market_on_open("SPY", 100, obs)
     assert status == cancel_status
-    assert ledger.entries[0].order_id == oid
-    assert ledger.entries[0].status == cancel_status
+    entries = ledger.entries()
+    assert entries[-1].order_id == oid
+    assert entries[-1].status == cancel_status
     assert obs.order_errors_total._value.get() == 1

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -7,7 +7,11 @@ def test_mock_market_on_open_records_ledger():
     oid, status = mock.place_market_on_open("SPY", 123.45)
     assert status == "filled"
     assert oid.startswith("mock-")
-    assert any(e.order_id == oid and e.ticker == "SPY" for e in ledger.entries)
+    entries = ledger.entries()
+    assert any(
+        e.order_id == oid and e.ticker == "SPY" and e.status == "filled"
+        for e in entries
+    )
 
 
 def test_min_notional_enforced():


### PR DESCRIPTION
## Summary
- replace in-memory ledger with append-only SQLite store
- log order intents and results and expose pending-intent replay helpers
- update brokers and scheduler to reconcile recorded intents

## Testing
- `pytest tests/test_brokers.py tests/test_broker_sdks.py tests/test_stable_allocator.py tests/test_profit_router.py -q`
- `pytest -q` *(fails: SyntaxError in src/quant_pipeline/training.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dda8dba4832db14c314cc3d6c320