### PR TITLE
Add triple barrier labeling and integrate into training

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,28 @@ This repository contains a minimalist quantitative trading pipeline. See the
 - [Data quality playbooks](docs/playbooks.md)
 - [Data source catalog](docs/catalog.md)
 - [Data Doctor before/after examples](docs/data_doctor.md)
+
+## Training
+
+The training pipeline can automatically derive meta-labels using the triple
+barrier method.  Provide labeling parameters to :class:`AutoTrainer` and the
+dataset passed to ``train_model`` will include a ``label`` column:
+
+```python
+from quant_pipeline.training import AutoTrainer
+
+trainer = AutoTrainer(
+    registry,
+    train_every_bars=100,
+    history_days=5,
+    max_challengers=3,
+    build_dataset=load_recent_data,
+    train_model=train_model,
+    label_horizon=5,
+    label_up_mult=2.0,
+    label_down_mult=1.5,
+)
+```
+
+The underlying labeling logic is exposed as
+``quant_pipeline.labels.triple_barrier`` for standalone use.

--- a/src/quant_pipeline/labels.py
+++ b/src/quant_pipeline/labels.py
@@ -1,0 +1,58 @@
+"""Label generation utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def triple_barrier(df: pd.DataFrame, horizon: int, up_mult: float, down_mult: float) -> pd.Series:
+    """Generate meta-labels using the triple barrier method.
+
+    The function inspects future ``high``/``low`` prices up to ``horizon``
+    steps and determines which barrier is touched first.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Must contain ``close``, ``high`` and ``low`` columns. A ``volatility``
+        column is optional and scales the barriers when present.
+    horizon : int
+        Number of rows to look ahead for the vertical barrier.
+    up_mult, down_mult : float
+        Multipliers applied to the volatility (or 1.0 when missing) to form the
+        upper and lower barriers respectively.
+
+    Returns
+    -------
+    Series
+        Values are ``1`` when the upper barrier is hit first, ``-1`` when the
+        lower barrier is hit and ``0`` if neither barrier is reached within the
+        horizon.
+    """
+
+    if horizon <= 0:
+        raise ValueError("horizon must be positive")
+
+    prices = df["close"].to_numpy()
+    highs = df["high"].to_numpy()
+    lows = df["low"].to_numpy()
+    vol = df["volatility"].to_numpy() if "volatility" in df.columns else np.ones(len(df))
+    labels = np.zeros(len(df), dtype=int)
+
+    n = len(df)
+    for i in range(n):
+        upper = prices[i] * (1 + up_mult * vol[i])
+        lower = prices[i] * (1 - down_mult * vol[i])
+        end = min(i + horizon, n - 1)
+        for j in range(i + 1, end + 1):
+            if highs[j] >= upper:
+                labels[i] = 1
+                break
+            if lows[j] <= lower:
+                labels[i] = -1
+                break
+    return pd.Series(labels, index=df.index, name="label")
+
+
+__all__ = ["triple_barrier"]

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -9,8 +9,10 @@ from typing import Any, Callable, Dict, Iterator, Tuple
 
 from concurrent.futures import ThreadPoolExecutor
 import numpy as np
+import pandas as pd
 
 from .model_registry import ModelRegistry
+from .labels import triple_barrier
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +30,9 @@ class AutoTrainer:
         build_dataset: Callable[[int], Any],
         train_model: Callable[[Any], Dict[str, str]],
         num_parallel: int = 1,
+        label_horizon: int | None = None,
+        label_up_mult: float = 1.0,
+        label_down_mult: float = 1.0,
     ) -> None:
         self.registry = registry
         self.train_every_bars = train_every_bars
@@ -36,6 +41,9 @@ class AutoTrainer:
         self.build_dataset = build_dataset
         self.train_model = train_model
         self.num_parallel = max(1, num_parallel)
+        self.label_horizon = label_horizon
+        self.label_up_mult = label_up_mult
+        self.label_down_mult = label_down_mult
         self._bar_count = 0
         self._event = threading.Event()
         self._stop = threading.Event()
@@ -76,7 +84,18 @@ class AutoTrainer:
     def _train_cycle(self) -> None:
         logger.info("training cycle started")
         dataset = self.build_dataset(self.history_days)
-
+        if (
+            self.label_horizon is not None
+            and isinstance(dataset, pd.DataFrame)
+        ):
+            labels = triple_barrier(
+                dataset,
+                self.label_horizon,
+                self.label_up_mult,
+                self.label_down_mult,
+            )
+            dataset = dataset.copy()
+            dataset["label"] = labels
 
         def _train() -> Dict[str, str]:
             return self.train_model(dataset)
@@ -113,37 +132,6 @@ class AutoTrainer:
 
         if registered:
             self.registry.prune_challengers(self.max_challengers)
-=======
-        from concurrent.futures import ThreadPoolExecutor
-
-        def _train() -> Dict[str, str]:
-            return self.train_model(dataset)
-
-        with ThreadPoolExecutor(max_workers=self.num_parallel) as ex:
-            futures = [ex.submit(_train) for _ in range(self.num_parallel)]
-            for fut in futures:
-                info = fut.result()
-                if not info:
-                    logger.warning("training produced no model")
-                    continue
-                model_id = self.registry.register_model(
-                    model_type=info["type"],
-                    genes_json=info.get("genes_json", "{}"),
-                    artifact_path=info["artifact_path"],
-                    calib_path=info["calib_path"],
-                    lstm_path=info.get("lstm_path"),
-                    scaler_path=info.get("scaler_path"),
-                    features_path=info.get("features_path"),
-                    thresholds_path=info.get("thresholds_path"),
-                    risk_rules_path=info.get("risk_rules_path"),
-                    ga_version=info.get("ga_version"),
-                    seed=info.get("seed"),
-                    data_hash=info.get("data_hash"),
-                    ts=int(time.time()),
-                )
-                logger.info("registered challenger %s for shadow eval", model_id)
-
-        self.registry.prune_challengers(self.max_challengers)
 
 
 class PurgedKFold:


### PR DESCRIPTION
## Summary
- implement triple barrier meta-labeling
- auto-generate labels during AutoTrainer cycles
- document training label integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dda753f4832d81bb63ed08e6755e