### PR TITLE
Fix training cycle duplication and markers

### DIFF
--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -113,37 +113,6 @@ class AutoTrainer:
 
         if registered:
             self.registry.prune_challengers(self.max_challengers)
-=======
-        from concurrent.futures import ThreadPoolExecutor
-
-        def _train() -> Dict[str, str]:
-            return self.train_model(dataset)
-
-        with ThreadPoolExecutor(max_workers=self.num_parallel) as ex:
-            futures = [ex.submit(_train) for _ in range(self.num_parallel)]
-            for fut in futures:
-                info = fut.result()
-                if not info:
-                    logger.warning("training produced no model")
-                    continue
-                model_id = self.registry.register_model(
-                    model_type=info["type"],
-                    genes_json=info.get("genes_json", "{}"),
-                    artifact_path=info["artifact_path"],
-                    calib_path=info["calib_path"],
-                    lstm_path=info.get("lstm_path"),
-                    scaler_path=info.get("scaler_path"),
-                    features_path=info.get("features_path"),
-                    thresholds_path=info.get("thresholds_path"),
-                    risk_rules_path=info.get("risk_rules_path"),
-                    ga_version=info.get("ga_version"),
-                    seed=info.get("seed"),
-                    data_hash=info.get("data_hash"),
-                    ts=int(time.time()),
-                )
-                logger.info("registered challenger %s for shadow eval", model_id)
-
-        self.registry.prune_challengers(self.max_challengers)
 
 
 class PurgedKFold:


### PR DESCRIPTION
## Summary
- remove stray merge marker and duplicate training block
- consolidate model registration and pruning in `AutoTrainer._train_cycle`

## Testing
- `python -m py_compile src/quant_pipeline/training.py`
- `pytest tests/test_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dda0c6b0832da1f2811a98052169