### PR TITLE
Add orderbook and news ingestion with validations

### DIFF
--- a/src/quant_pipeline/models.py
+++ b/src/quant_pipeline/models.py
@@ -68,3 +68,23 @@ class PerpMetrics(BaseModel):
         if v < 0:
             raise ValueError("timestamp must be positive milliseconds")
         return v
+
+
+class NewsSentiment(BaseModel):
+    timestamp: int
+    symbol: str
+    sentiment: float
+    source: str
+    timeframe: str
+
+    @validator("timestamp")
+    def ts_ms(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("timestamp must be positive milliseconds")
+        return v
+
+    @validator("sentiment")
+    def sentiment_range(cls, v: float) -> float:
+        if v < -1 or v > 1:
+            raise ValueError("sentiment must be between -1 and 1")
+        return v

--- a/src/quant_pipeline/storage.py
+++ b/src/quant_pipeline/storage.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional, Sequence, Type
 
 import pandas as pd
 
-from .models import BarOHLCV, OrderBookBest, PerpMetrics
+from .models import BarOHLCV, OrderBookBest, PerpMetrics, NewsSentiment
 
 # Base directory for lake storage
 LAKE_PATH = Path(__file__).resolve().parents[2] / "lake"
@@ -18,6 +18,7 @@ SCHEMAS = {
     "bar_ohlcv": BarOHLCV,
     "orderbook_best": OrderBookBest,
     "perp_metrics": PerpMetrics,
+    "news": NewsSentiment,
 }
 
 

--- a/tests/test_ingest_orderbook_news.py
+++ b/tests/test_ingest_orderbook_news.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+from ingest import IngestService
+from quant_pipeline.observability import Observability
+from quant_pipeline import ingest as qingest
+
+
+def fake_orderbook(symbol, timeframe="1s", start=None, end=None):
+    base = 1_600_000_000_000
+    data = [
+        {
+            "timestamp": base,
+            "bid1": 1.0,
+            "ask1": 1.1,
+            "bid_sz1": 2.0,
+            "ask_sz1": 2.5,
+            "trades_buy_vol": 1.0,
+            "trades_sell_vol": 1.2,
+        },
+        {
+            "timestamp": base + 1000,
+            "bid1": 1.05,
+            "ask1": 1.15,
+            "bid_sz1": 2.1,
+            "ask_sz1": 2.4,
+            "trades_buy_vol": 0.5,
+            "trades_sell_vol": 0.7,
+        },
+    ]
+    return pd.DataFrame(data)
+
+
+def fake_news(provider, symbols, start=None, end=None):
+    base = 1_600_000_000_000
+    rows = []
+    for sym in symbols:
+        rows.append({"timestamp": base, "sentiment": 0.1, "symbol": sym})
+        rows.append({"timestamp": base + 60_000, "sentiment": -0.2, "symbol": sym})
+    return pd.DataFrame(rows)
+
+
+def test_ingest_orderbook(tmp_path, monkeypatch):
+    obs = Observability()
+    svc = IngestService(lake_path=tmp_path / "lake", observability=obs)
+    svc.ingest_orderbook(fake_orderbook, ["BTC/USDT"], timeframe="1s")
+    miss = obs.data_missing_bars_ratio.labels(symbol="BTC-USDT", timeframe="1s")._value.get()
+    dup = obs.data_dup_ratio.labels(symbol="BTC-USDT")._value.get()
+    lat = obs.latency_ms._sum.get()
+    assert miss == 0.0
+    assert dup == 0.0
+    assert lat > 0.0
+
+
+def test_ingest_news(tmp_path, monkeypatch):
+    monkeypatch.setattr(qingest, "fetch_news_sentiment", fake_news)
+    obs = Observability()
+    svc = IngestService(lake_path=tmp_path / "lake", observability=obs)
+    svc.ingest_news("http://api/{symbol}", ["BTC"], timeframe="1h")
+    dup = obs.data_dup_ratio.labels(symbol="BTC")._value.get()
+    lat = obs.latency_ms._sum.get()
+    assert dup == 0.0
+    assert lat > 0.0


### PR DESCRIPTION
## Summary
- add ingestion adapters for order book snapshots and news sentiment
- support orderbook and news ingestion in service with validation and metrics
- define `NewsSentiment` model and store orderbook/news tables in the data lake

## Testing
- `pytest tests/test_ingest_service.py tests/test_ingest_orderbook_news.py -q`
- `pytest tests/test_storage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ec890f1c832d856e55f8e2909869