### PR TITLE
Add LSTM dataset windows with PurgedKFold splits

### DIFF
--- a/src/quant_pipeline/datasets.py
+++ b/src/quant_pipeline/datasets.py
@@ -1,0 +1,44 @@
+"""Dataset utilities for model training."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def make_lstm_windows(df: pd.DataFrame, seq_len: int):
+    """Generate sliding windows for LSTM models.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe sorted by time.  Must contain a ``label`` column; all
+        other columns are treated as features.
+    seq_len : int
+        Length of each window.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        ``X`` with shape ``(n_samples, seq_len, n_features)`` and ``y`` with
+        shape ``(n_samples,)``.
+    """
+    if "label" not in df.columns:
+        raise ValueError("missing 'label' column")
+    if seq_len <= 0:
+        raise ValueError("seq_len must be positive")
+    if len(df) <= seq_len:
+        raise ValueError("df must contain more rows than seq_len")
+
+    feature_cols = [c for c in df.columns if c != "label"]
+    X = []
+    y = []
+    for end in range(seq_len, len(df)):
+        start = end - seq_len
+        window = df.iloc[start:end][feature_cols].values
+        target = df.iloc[end]["label"]
+        X.append(window)
+        y.append(target)
+    return np.asarray(X), np.asarray(y)
+
+
+__all__ = ["make_lstm_windows"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+from quant_pipeline.datasets import make_lstm_windows
+from quant_pipeline.model_registry import ModelRegistry
+from quant_pipeline.training import AutoTrainer
+
+
+def _dummy_loader(_):
+    n = 30
+    return pd.DataFrame({
+        "feat": np.arange(n, dtype=float),
+        "label": np.arange(n, dtype=float),
+    })
+
+
+def _dummy_train(_):
+    return {}
+
+
+def test_make_lstm_windows_shapes():
+    df = _dummy_loader(0)
+    X, y = make_lstm_windows(df, seq_len=5)
+    assert X.shape == (25, 5, 1)
+    assert y.shape == (25,)
+
+
+def test_autotrainer_build_dataset_no_leakage(tmp_path):
+    reg = ModelRegistry(str(tmp_path / "db.db"))
+    trainer = AutoTrainer(
+        reg,
+        train_every_bars=1,
+        history_days=5,
+        max_challengers=1,
+        dataset_loader=_dummy_loader,
+        train_model=_dummy_train,
+        seq_len=5,
+        cv_splits=3,
+        embargo=2,
+    )
+    X, y, splits = trainer.build_dataset(_dummy_loader(0))
+    assert X.shape == (25, 5, 1)
+    assert y.shape == (25,)
+    for train_idx, test_idx in splits:
+        assert set(train_idx).isdisjoint(set(test_idx))
+        for ti in test_idx:
+            assert all(abs(ti - tr) > 2 for tr in train_idx)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,4 +1,6 @@
 import time
+import numpy as np
+import pandas as pd
 from quant_pipeline.model_registry import ModelRegistry
 from quant_pipeline.training import AutoTrainer
 
@@ -17,8 +19,13 @@ def test_autotrainer_registers_and_prunes(tmp_path):
 
     trained = []
 
-    def build_dataset(days):
-        return {"days": days}
+    def dataset_loader(days):
+        n = 10
+        df = pd.DataFrame({
+            "feat": np.arange(n, dtype=float),
+            "label": np.arange(n, dtype=float),
+        })
+        return df
 
     def train_model(_):
         idx = len(trained)
@@ -36,8 +43,10 @@ def test_autotrainer_registers_and_prunes(tmp_path):
         train_every_bars=1,
         history_days=3,
         max_challengers=2,
-        build_dataset=build_dataset,
+        dataset_loader=dataset_loader,
         train_model=train_model,
+        seq_len=2,
+        cv_splits=2,
     )
 
     trainer.start()


### PR DESCRIPTION
## Summary
- Add `make_lstm_windows` utility to build sliding windows for sequential models
- Extend `AutoTrainer` to construct purged cross-validation datasets for LSTM training
- Cover new data generator with tests for window shapes and leakage via `PurgedKFold`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1ec8a0c78832d80d2f948782e4eca