### PR TITLE
Add corporate and macro ingestion

### DIFF
--- a/src/quant_pipeline/models.py
+++ b/src/quant_pipeline/models.py
@@ -88,3 +88,32 @@ class NewsSentiment(BaseModel):
         if v < -1 or v > 1:
             raise ValueError("sentiment must be between -1 and 1")
         return v
+
+
+class CorporateAction(BaseModel):
+    timestamp: int
+    symbol: str
+    source: str
+    timeframe: str
+    split_ratio: float | None = None
+    dividend: float | None = None
+
+    @validator("timestamp")
+    def ts_ms(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("timestamp must be positive milliseconds")
+        return v
+
+
+class MacroIndicator(BaseModel):
+    timestamp: int
+    symbol: str
+    value: float
+    source: str
+    timeframe: str
+
+    @validator("timestamp")
+    def ts_ms(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("timestamp must be positive milliseconds")
+        return v

--- a/src/quant_pipeline/storage.py
+++ b/src/quant_pipeline/storage.py
@@ -5,7 +5,14 @@ from typing import Iterable, Optional, Sequence, Type
 
 import pandas as pd
 
-from .models import BarOHLCV, OrderBookBest, PerpMetrics, NewsSentiment
+from .models import (
+    BarOHLCV,
+    OrderBookBest,
+    PerpMetrics,
+    NewsSentiment,
+    CorporateAction,
+    MacroIndicator,
+)
 
 # Base directory for lake storage
 LAKE_PATH = Path(__file__).resolve().parents[2] / "lake"
@@ -19,6 +26,8 @@ SCHEMAS = {
     "orderbook_best": OrderBookBest,
     "perp_metrics": PerpMetrics,
     "news": NewsSentiment,
+    "corporate": CorporateAction,
+    "macro": MacroIndicator,
 }
 
 


### PR DESCRIPTION
## Summary
- add `CorporateMacroAdapter` for corporate actions and macro indicators
- ingest corporate and macro data with validation and observability metrics
- extend storage schemas and training API for new datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f246fdfc832d8d595d9e898c035c