### PR TITLE
Add OHLCV resampling and integrate into ingest service

### DIFF
--- a/src/ingest/service.py
+++ b/src/ingest/service.py
@@ -10,6 +10,7 @@ from quant_pipeline.doctor import validate_ohlcv
 from quant_pipeline.ingest import ingest_ohlcv_ccxt, ingest_orderbook, ingest_news
 from quant_pipeline.observability import Observability
 from quant_pipeline.storage import read_table
+from quant_pipeline.utils import resample_ohlcv
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +74,7 @@ class IngestService:
                 timeframe=timeframe,
                 base_path=self.lake_path,
             )
+            df = resample_ohlcv(df, timeframe)
             validated = validate_ohlcv(df, tf_ms)
             diffs = validated["timestamp"].diff().dropna()
             missing = (diffs > tf_ms).sum()

--- a/src/quant_pipeline/utils.py
+++ b/src/quant_pipeline/utils.py
@@ -5,6 +5,8 @@ import time
 from contextlib import contextmanager
 from typing import Callable, Tuple, Type, TypeVar
 
+import pandas as pd
+
 from .logging import get_logger
 
 T = TypeVar("T")
@@ -50,3 +52,71 @@ def retry(
         return wrapper
 
     return decorator
+
+
+def resample_ohlcv(df: pd.DataFrame, timeframe: str) -> pd.DataFrame:
+    """Resample OHLCV data and fix common data issues.
+
+    The function aligns bars to the desired ``timeframe`` boundary, detects
+    potential stock splits by looking at large gaps between consecutive bars,
+    clips extreme outliers and returns a cleaned DataFrame with millisecond
+    timestamps.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Raw OHLCV data containing at least ``timestamp``, ``open``, ``high``,
+        ``low`` and ``close`` columns where ``timestamp`` is expressed in
+        milliseconds.
+    timeframe : str
+        Pandas resampling rule such as ``"1h"`` or ``"1D"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Resampled and adjusted DataFrame with millisecond ``timestamp``.
+    """
+
+    if df.empty:
+        return df
+
+    out = df.copy()
+    out["timestamp"] = pd.to_datetime(out["timestamp"], unit="ms", utc=True)
+    out = out.set_index("timestamp").sort_index()
+
+    # ------------------------------------------------------------------
+    # detect and adjust stock splits using close/next open ratios
+    # ------------------------------------------------------------------
+    if {"open", "close"}.issubset(out.columns) and len(out) >= 2:
+        ratio = out["close"].shift(1) / out["open"]
+        split_points = ratio[(ratio > 1.5) | (ratio < 0.67)]
+        if not split_points.empty:
+            price_cols = [c for c in ["open", "high", "low", "close"] if c in out.columns]
+            for ts, r in split_points.items():
+                if r and r != 0:
+                    out.loc[out.index < ts, price_cols] = out.loc[out.index < ts, price_cols].div(
+                        r
+                    )
+
+    # ------------------------------------------------------------------
+    # winsorise outliers to reduce the impact of bad ticks
+    # ------------------------------------------------------------------
+    if len(out) >= 10:
+        for col in [c for c in ["open", "high", "low", "close", "volume"] if c in out.columns]:
+            q_low = out[col].quantile(0.01)
+            q_high = out[col].quantile(0.99)
+            out[col] = out[col].clip(q_low, q_high)
+
+    # ------------------------------------------------------------------
+    # resample to regular timeframe boundaries
+    # ------------------------------------------------------------------
+    o = out["open"].resample(timeframe).first()
+    h = out["high"].resample(timeframe).max()
+    l = out["low"].resample(timeframe).min()
+    c = out["close"].resample(timeframe).last()
+    v = out.get("volume", pd.Series(dtype=float)).resample(timeframe).sum()
+    out = pd.concat([o, h, l, c, v], axis=1, keys=["open", "high", "low", "close", "volume"])
+    out = out.dropna(how="all").reset_index()
+    out["timestamp"] = out["timestamp"].astype("int64") // 10 ** 6
+    return out
+

--- a/tests/test_resample_ohlcv.py
+++ b/tests/test_resample_ohlcv.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from quant_pipeline.utils import resample_ohlcv
+
+
+def test_resample_ohlcv_detects_split():
+    base = 1_600_000_000_000
+    tf = 3_600_000
+    df = pd.DataFrame(
+        [
+            [base, 100.0, 110.0, 90.0, 110.0, 100],
+            [base + tf, 55.0, 56.0, 54.0, 55.0, 200],
+        ],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+
+    out = resample_ohlcv(df, "1h")
+    first = out.iloc[0]
+    assert first.open == 50.0
+    assert first.close == 55.0
+
+
+def test_resample_ohlcv_aligns_timeframe():
+    base = 1_600_000_000_000
+    tf = 3_600_000
+    df = pd.DataFrame(
+        [
+            [base + 1_000, 1.0, 2.0, 0.5, 1.5, 10],
+            [base + tf + 1_000, 1.6, 2.6, 1.1, 2.0, 20],
+        ],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+
+    out = resample_ohlcv(df, "1h")
+    expected_start = base - (base % tf)
+    assert list(out["timestamp"]) == [expected_start, expected_start + tf]
+    diffs = out["timestamp"].diff().dropna()
+    assert (diffs == tf).all()


### PR DESCRIPTION
## Summary
- add `resample_ohlcv` utility to normalize OHLCV series, fix splits/outliers, and align timestamps
- integrate the resampling step in `IngestService.ingest_ccxt` prior to validation
- test split adjustment and timeframe alignment

## Testing
- `pytest tests/test_resample_ohlcv.py tests/test_ingest_service.py::test_service_records_metrics -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f247fd74832d94ae835eb9e2aa41