### PR TITLE
Fix merge artifacts in service and decision modules

### DIFF
--- a/src/ingest/service.py
+++ b/src/ingest/service.py
@@ -16,10 +16,8 @@ from quant_pipeline.ingest import (
     ingest_news,
 )
 from quant_pipeline.observability import Observability
-from quant_pipeline.storage import read_table
-from quant_pipeline.utils import resample_ohlcv
-=======
 from quant_pipeline.storage import read_table, to_parquet
+from quant_pipeline.utils import resample_ohlcv
 
 
 

--- a/src/quant_pipeline/decision.py
+++ b/src/quant_pipeline/decision.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 
 from typing import Dict, List
-=======
-from typing import Dict
 from collections import deque
 from statistics import median
 


### PR DESCRIPTION
## Summary
- Consolidate storage import in `ingest.service` and remove merge markers
- Simplify typing imports in `quant_pipeline.decision`

## Testing
- `python -m py_compile src/ingest/service.py src/quant_pipeline/decision.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1f5bdead4832daef1dcb27b6b2c9c