### PR TITLE
Add data quality check in decision loop

### DIFF
--- a/src/ingest/service.py
+++ b/src/ingest/service.py
@@ -16,10 +16,8 @@ from quant_pipeline.ingest import (
     ingest_news,
 )
 from quant_pipeline.observability import Observability
-from quant_pipeline.storage import read_table
-from quant_pipeline.utils import resample_ohlcv
-=======
 from quant_pipeline.storage import read_table, to_parquet
+from quant_pipeline.utils import resample_ohlcv
 
 
 

--- a/src/quant_pipeline/decision.py
+++ b/src/quant_pipeline/decision.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 
 from typing import Dict, List
-=======
-from typing import Dict
 from collections import deque
 from statistics import median
 
@@ -16,6 +14,7 @@ from .oms import OMS
 from .observability import Observability
 from .risk import RiskManager, ATRCalculator
 from .state import load_snapshot, save_snapshot
+from .quality import quality_check
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +126,9 @@ class DecisionLoop:
                 pass
 
     def on_bar(self, bar: Dict[str, float]) -> None:
+        if not quality_check(bar):
+            self.obs.increment_quality_errors()
+            return
         feats = self.fb.update(bar)
         scaled = self.scaler.transform(feats[["ret"]])
         self.scaler.update(feats[["ret"]])

--- a/src/quant_pipeline/observability.py
+++ b/src/quant_pipeline/observability.py
@@ -78,6 +78,11 @@ class Observability:
             "Total number of order send errors",
             registry=self.registry,
         )
+        self.quality_errors_total = Counter(
+            "quality_errors_total",
+            "Total number of market data quality errors",
+            registry=self.registry,
+        )
         self.slippage_bps = Histogram(
             "slippage_bps",
             "Observed slippage in basis points",
@@ -179,6 +184,9 @@ class Observability:
     def increment_order_errors(self, n: int = 1) -> None:
         self.order_errors_total.inc(n)
         self._send_alert("Order error encountered")
+
+    def increment_quality_errors(self, n: int = 1) -> None:
+        self.quality_errors_total.inc(n)
 
     def observe_slippage(self, bps: float, threshold: float | None = None) -> None:
         self.slippage_bps.observe(bps)

--- a/src/quant_pipeline/quality.py
+++ b/src/quant_pipeline/quality.py
@@ -1,0 +1,41 @@
+"""Market data quality checks for streaming bars."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict
+
+# Minimal fields required for downstream components
+REQUIRED_FIELDS = {"timestamp", "symbol", "close"}
+
+def quality_check(bar: Dict[str, float], *, max_delay: float = 60.0) -> bool:
+    """Validate presence of required fields and freshness of a bar.
+
+    Parameters
+    ----------
+    bar:
+        Market data tick containing OHLCV information.
+    max_delay:
+        Maximum allowed age of the bar in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` if the bar passes all quality checks, ``False`` otherwise.
+    """
+    if not REQUIRED_FIELDS.issubset(bar):
+        return False
+    try:
+        ts = float(bar["timestamp"])
+    except (TypeError, ValueError):
+        return False
+    # Normalize to seconds if timestamp provided in milliseconds
+    if ts > 1e12:
+        ts /= 1000.0
+    # Only enforce freshness if timestamp resembles a UNIX epoch value
+    if ts > 1e9 and time.time() - ts > max_delay:
+        return False
+    return True
+
+
+__all__ = ["quality_check"]

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,74 @@
+import time
+import numpy as np
+import pandas as pd
+
+from quant_pipeline.quality import quality_check
+from quant_pipeline.decision import DecisionLoop
+from quant_pipeline.simple_lstm import SimpleLSTM
+from quant_pipeline.oms import OMS
+from quant_pipeline.risk import RiskManager
+from quant_pipeline.observability import Observability
+
+
+class DummyExchange:
+    def __init__(self):
+        self.orders = []
+
+    def create_order(self, symbol, side, qty, price, client_id, leverage=None):
+        self.orders.append({"symbol": symbol, "side": side, "qty": qty})
+        return "1"
+
+    def cancel_order(self, order_id):
+        pass
+
+    def get_open_orders(self):
+        return []
+
+
+def test_quality_check_fields_and_freshness():
+    now = time.time()
+    bar = {
+        "timestamp": now,
+        "symbol": "BTC-USDT",
+        "open": 1.0,
+        "high": 1.0,
+        "low": 1.0,
+        "close": 1.0,
+        "volume": 1.0,
+    }
+    assert quality_check(bar)
+    bad = bar.copy()
+    del bad["close"]
+    assert not quality_check(bad)
+    stale = bar.copy()
+    stale["timestamp"] = now - 120
+    assert not quality_check(stale)
+
+
+def test_decision_loop_counts_quality_errors(tmp_path):
+    ex = DummyExchange()
+    oms = OMS(ex, {"BTC-USDT": {"tick_size": 1, "lot_size": 0, "min_notional": 0}})
+    risk = RiskManager(
+        max_dd_daily=1.0,
+        max_dd_weekly=1.0,
+        latency_threshold=1000,
+        latency_window=1,
+        pause_minutes=1,
+    )
+    obs = Observability()
+    model = SimpleLSTM()
+    train = pd.DataFrame({"ret": np.linspace(-0.01, 0.01, 20)})
+    model.fit(train)
+    loop = DecisionLoop(model, risk, oms, obs, ema_span=2, threshold=0.0, cooldown=0)
+    bad_bar = {
+        "timestamp": time.time(),
+        "symbol": "BTC-USDT",
+        "open": 1.0,
+        "high": 1.0,
+        "low": 1.0,
+        # missing close field to trigger quality error
+        "volume": 1.0,
+    }
+    loop.on_bar(bad_bar)
+    assert obs.quality_errors_total._value.get() == 1.0
+    assert ex.orders == []


### PR DESCRIPTION
## Summary
- add `quality_check` to validate bar fields and freshness
- track quality errors via Observability metric
- skip DecisionLoop processing when bar fails quality checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f5bd5170832d890a9503e0230367