### PR TITLE
feat: add unified trading engine

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,14 @@
+# Example configuration shared across modes.
+# The `mode` field selects the execution client and data source used by the
+# runners.  Valid values: `backtest`, `walkforward`, `live`.
+mode: backtest
+
+risk:
+  max_position: 10
+
+execution:
+  fee_bps: 1      # commissions in basis points
+  slippage_bps: 2 # extra slippage applied by the simulator
+
+data:
+  source: csv

--- a/src/bt_runner.py
+++ b/src/bt_runner.py
@@ -1,0 +1,50 @@
+"""Example backtest runner using :class:`TradingEngine`.
+
+The script wires together a dummy model and feature builder with the
+:class:`SimExecutionClient` so that the same engine logic can later be
+used for walk-forward or live trading.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from engine import TradingEngine
+from execution import CostModel, SimExecutionClient
+from risk import RiskLimits, RiskManager
+
+
+class DummyModel:
+    """Model with a ``predict`` method returning the provided feature."""
+
+    def predict(self, features):  # pragma: no cover - trivial
+        return features["signal"]
+
+
+def build_features(bar):  # pragma: no cover - trivial
+    # For illustration the feature is simply price momentum
+    return {"signal": bar["price"] - bar.get("ma", bar["price"])}
+
+
+def main(cfg_path: str = "config.yaml") -> None:
+    cfg = yaml.safe_load(open(cfg_path))
+    risk = RiskManager(RiskLimits(max_position=cfg["risk"]["max_position"]))
+    cost = CostModel(**cfg["execution"])
+    exec_client = SimExecutionClient(cost_model=cost)
+    engine = TradingEngine(DummyModel(), build_features, risk, exec_client)
+
+    # Example price series ------------------------------------------------
+    data = [
+        {"symbol": "XYZ", "price": 100.0, "ma": 100.0},
+        {"symbol": "XYZ", "price": 101.0, "ma": 100.5},
+        {"symbol": "XYZ", "price": 99.5, "ma": 100.5},
+    ]
+    for bar in data:
+        engine.on_bar(bar)
+
+    print("Final positions:", exec_client.positions())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()
+

--- a/src/engine.py
+++ b/src/engine.py
@@ -1,0 +1,56 @@
+"""Unified trading engine used by all modes.
+
+The :class:`TradingEngine` glues together feature construction, model
+prediction, position sizing, risk management and order execution.  The
+same engine is used by backtests, walk-forward experiments and live
+trading simply by swapping the :class:`ExecutionClient` instance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from execution import ExecutionClient, Order
+from risk import RiskManager
+
+
+@dataclass
+class TradingEngine:
+    """Minimal yet extensible trading engine."""
+
+    model: Any
+    feature_builder: Callable[[Any], Any]
+    risk_manager: RiskManager
+    execution_client: ExecutionClient
+    size_fn: Optional[Callable[[float], float]] = None
+
+    def __post_init__(self) -> None:
+        # Default position sizing: buy one unit per unit signal
+        if self.size_fn is None:
+            self.size_fn = lambda s: 1.0 if s > 0 else (-1.0 if s < 0 else 0.0)
+
+    # ------------------------------------------------------------------
+    def on_bar(self, market_data: Any) -> Optional[str]:
+        """Process one market data event and optionally send an order."""
+
+        features = self.feature_builder(market_data)
+        signal = float(self.model.predict(features))
+        qty = self.size_fn(signal)
+        if qty == 0:
+            return None
+        side_price = getattr(market_data, "price", None)
+        order = Order(symbol=getattr(market_data, "symbol", ""), qty=qty, price=side_price)
+        if not self.risk_manager.pre_trade(order, self.execution_client.positions()):
+            return None
+        order_id = self.execution_client.send(order)
+        self.risk_manager.post_trade(order, self.execution_client.positions())
+        return order_id
+
+    # Convenience aliases ------------------------------------------------
+    def positions(self):  # pragma: no cover - simple pass-through
+        return self.execution_client.positions()
+
+    def clock(self):  # pragma: no cover - simple pass-through
+        return self.execution_client.clock()
+

--- a/src/execution.py
+++ b/src/execution.py
@@ -1,0 +1,165 @@
+"""Execution client interfaces for trading modes.
+
+This module defines a minimal execution layer with a common
+`ExecutionClient` interface and two concrete implementations:
+`SimExecutionClient` for simulations/backtests and
+`BrokerExecutionClient` as a placeholder for real broker APIs.
+
+The goal is to decouple order generation from how orders are actually
+sent or filled, enabling backtest, walk-forward and live modes to share
+identical trading logic.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+import uuid
+
+
+# ---------------------------------------------------------------------------
+# Order representation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Order:
+    """Simple order container used by the engine.
+
+    Attributes
+    ----------
+    symbol: str
+        Instrument identifier.
+    qty: float
+        Quantity to trade. Positive values represent a buy and negative
+        values a sell; the :class:`TradingEngine` takes care of converting
+        raw signals into signed quantities.
+    price: Optional[float]
+        Optional limit price. ``None`` implies market order in the
+        simulated client.
+    id: str
+        Unique order identifier generated automatically when the order is
+        instantiated.
+    """
+
+    symbol: str
+    qty: float
+    price: Optional[float] = None
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+
+# ---------------------------------------------------------------------------
+# Execution client interface
+# ---------------------------------------------------------------------------
+
+class ExecutionClient(ABC):
+    """Abstract base class for execution backends.
+
+    The engine depends only on this interface making it possible to swap
+    a simulated execution layer with a live broker without changing the
+    decision logic.
+    """
+
+    @abstractmethod
+    def send(self, order: Order) -> str:
+        """Send an order to the venue.
+
+        Returns
+        -------
+        str
+            The unique identifier of the submitted order.
+        """
+
+    @abstractmethod
+    def cancel(self, order_id: str) -> None:
+        """Cancel an existing order."""
+
+    @abstractmethod
+    def positions(self) -> Dict[str, float]:
+        """Return current positions keyed by symbol."""
+
+    @abstractmethod
+    def clock(self) -> datetime:
+        """Return the current timestamp according to the venue."""
+
+
+# ---------------------------------------------------------------------------
+# Helper: simple cost model used by the simulator
+# ---------------------------------------------------------------------------
+
+class CostModel:
+    """Applies linear slippage and fees in basis points."""
+
+    def __init__(self, fee_bps: float = 0.0, slippage_bps: float = 0.0):
+        self.fee_bps = fee_bps
+        self.slippage_bps = slippage_bps
+
+    def apply(self, price: float, qty: float) -> float:
+        """Return total cost including slippage and fees."""
+
+        slip_price = price * (1 + self.slippage_bps / 10_000)
+        fee = price * abs(qty) * self.fee_bps / 10_000
+        return slip_price * qty + fee
+
+
+# ---------------------------------------------------------------------------
+# Concrete implementations
+# ---------------------------------------------------------------------------
+
+class SimExecutionClient(ExecutionClient):
+    """In-memory execution client for tests/backtests.
+
+    Orders are assumed to fill immediately at the provided price.  A
+    :class:`CostModel` instance is used to emulate fees and slippage.
+    """
+
+    def __init__(self, cost_model: Optional[CostModel] = None):
+        self.cost_model = cost_model or CostModel()
+        self._positions: Dict[str, float] = {}
+        self._ledger: List[Order] = []
+
+    def send(self, order: Order) -> str:  # pragma: no cover - trivial
+        cost = self.cost_model.apply(order.price or 0.0, order.qty)
+        self._positions[order.symbol] = self._positions.get(order.symbol, 0.0) + order.qty
+        self._ledger.append(order)
+        # In a real backtest we would store PnL including cost here.
+        return order.id
+
+    def cancel(self, order_id: str) -> None:  # pragma: no cover - stub
+        # In the simulation orders fill immediately, so cancel is a no-op.
+        pass
+
+    def positions(self) -> Dict[str, float]:  # pragma: no cover - trivial
+        return dict(self._positions)
+
+    def clock(self) -> datetime:  # pragma: no cover - trivial
+        return datetime.now(timezone.utc)
+
+
+class BrokerExecutionClient(ExecutionClient):
+    """Placeholder implementation for live trading.
+
+    In a production system this class would wrap a library such as CCXT,
+    IBKR, or a broker SDK.  The methods currently log their usage making
+    it easy to later plug in the real API calls.
+    """
+
+    def __init__(self):
+        self._positions: Dict[str, float] = {}
+
+    def send(self, order: Order) -> str:  # pragma: no cover - stub
+        # Replace the print statements with real broker API calls.
+        print(f"LIVE ORDER -> {order.symbol} {order.qty}@{order.price}")
+        self._positions[order.symbol] = self._positions.get(order.symbol, 0.0) + order.qty
+        return order.id
+
+    def cancel(self, order_id: str) -> None:  # pragma: no cover - stub
+        print(f"CANCEL ORDER -> {order_id}")
+
+    def positions(self) -> Dict[str, float]:  # pragma: no cover - trivial
+        return dict(self._positions)
+
+    def clock(self) -> datetime:  # pragma: no cover - trivial
+        return datetime.now(timezone.utc)
+

--- a/src/quant_pipeline/ensemble.py
+++ b/src/quant_pipeline/ensemble.py
@@ -1,0 +1,92 @@
+"""Simple ensemble utilities blending multiple model signals.
+
+This module introduces a light-weight ensemble mechanism that combines the
+outputs of heterogeneous models (e.g. tree-based models, neural networks and
+rule based signals).  It is intentionally small but showcases how different
+sources of predictive signals can be merged prior to risk management and order
+slicing.
+
+Examples
+--------
+>>> from sklearn.linear_model import LogisticRegression
+>>> from .simple_lstm import SimpleLSTM
+>>> from .ensemble import SignalEnsemble
+>>> lr = LogisticRegression()
+>>> lstm = SimpleLSTM(input_size=3, hidden_size=16)
+>>> ens = SignalEnsemble({"lr": lr, "lstm": lstm})
+>>> blended = ens.blend({"lr": 0.3, "lstm": -0.1}, weights={"lr": 0.7, "lstm": 0.3})
+"""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+import numpy as np
+
+
+class SignalEnsemble:
+    """Blend signals from multiple models.
+
+    Parameters
+    ----------
+    models : mapping
+        Dictionary of model objects exposing a ``predict`` method.
+    default_weights : mapping, optional
+        Fallback weights used when ``blend`` is called without explicit
+        weights.  They will be normalised to sum to one.
+    """
+
+    def __init__(
+        self,
+        models: Mapping[str, object],
+        *,
+        default_weights: Mapping[str, float] | None = None,
+    ) -> None:
+        self.models = dict(models)
+        self.default_weights = (
+            dict(default_weights) if default_weights is not None else None
+        )
+
+    def predict(self, name: str, X) -> np.ndarray:
+        """Run inference with one of the underlying models."""
+
+        model = self.models[name]
+        if not hasattr(model, "predict"):
+            raise AttributeError(f"model {name} has no predict method")
+        return np.asarray(model.predict(X))
+
+    def blend(
+        self,
+        signals: Mapping[str, np.ndarray | float],
+        *,
+        weights: Mapping[str, float] | None = None,
+    ) -> np.ndarray:
+        """Blend already-computed signals.
+
+        ``signals`` may contain scalars or numpy arrays.  Missing models will
+        raise a ``KeyError``.  ``weights`` default to ``default_weights``
+        provided at construction time.  The returned blended signal is a numpy
+        array whose length matches the first signal encountered.
+        """
+
+        if weights is None:
+            if self.default_weights is None:
+                raise ValueError("weights must be provided")
+            weights = self.default_weights
+
+        total = sum(weights.values())
+        if total == 0:
+            raise ValueError("weights sum to zero")
+
+        blended = None
+        for name, sig in signals.items():
+            if name not in weights:
+                continue
+            w = weights[name] / total
+            arr = np.asarray(sig)
+            blended = arr * w if blended is None else blended + arr * w
+        if blended is None:
+            raise ValueError("no overlapping signals and weights")
+        return blended
+
+
+__all__ = ["SignalEnsemble"]

--- a/src/risk.py
+++ b/src/risk.py
@@ -1,0 +1,56 @@
+"""Basic risk management utilities.
+
+The real project contains a fairly involved risk module.  This simplified
+version keeps only the pieces required by the example trading engine so
+that backtest, walk-forward and live modes can share the same interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from execution import Order
+
+
+@dataclass
+class RiskLimits:
+    """Configuration for simple notional limits."""
+
+    max_position: float = 0.0  # absolute quantity limit per symbol
+
+
+class RiskManager:
+    """Very small risk manager used by :class:`TradingEngine`.
+
+    Methods ``pre_trade`` and ``post_trade`` are intentionally
+    straightforward but documented so they can easily be extended with
+    more sophisticated checks (drawdown, latency, etc.).
+    """
+
+    def __init__(self, limits: RiskLimits):
+        self.limits = limits
+
+    # ------------------------------------------------------------------
+    # Hooks called by the engine
+    # ------------------------------------------------------------------
+    def pre_trade(self, order: Order, positions: Dict[str, float]) -> bool:
+        """Return ``True`` if the order respects position limits."""
+
+        current = positions.get(order.symbol, 0.0)
+        proposed = current + order.qty
+        if abs(proposed) > self.limits.max_position:
+            return False
+        return True
+
+    def post_trade(self, order: Order, positions: Dict[str, float]) -> None:
+        """Placeholder post-trade hook.
+
+        In a full featured implementation this method would update
+        drawdown statistics, latency measurements, etc.  The current
+        version simply exists so the engine has a stable callback point.
+        """
+
+        # No-op for now, reserved for future extensions.
+        return
+

--- a/src/wf_runner.py
+++ b/src/wf_runner.py
@@ -1,0 +1,45 @@
+"""Minimal walk-forward example using the unified engine.
+
+A real walk-forward pipeline would retrain the model on each in-sample
+window.  For simplicity this example just loops over data and resets the
+engine to illustrate how :class:`SimExecutionClient` can be reused.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from engine import TradingEngine
+from execution import CostModel, SimExecutionClient
+from risk import RiskLimits, RiskManager
+from bt_runner import DummyModel, build_features
+
+
+def main(cfg_path: str = "config.yaml") -> None:
+    cfg = yaml.safe_load(open(cfg_path))
+    risk = RiskManager(RiskLimits(max_position=cfg["risk"]["max_position"]))
+    cost = CostModel(**cfg["execution"])
+    exec_client = SimExecutionClient(cost_model=cost)
+    engine = TradingEngine(DummyModel(), build_features, risk, exec_client)
+
+    # Split data into two folds -------------------------------------------
+    data = [
+        {"symbol": "XYZ", "price": 100.0, "ma": 100.0},
+        {"symbol": "XYZ", "price": 102.0, "ma": 101.0},  # first fold
+        {"symbol": "XYZ", "price": 101.0, "ma": 101.5},
+        {"symbol": "XYZ", "price": 103.0, "ma": 102.0},  # second fold
+    ]
+    split = len(data) // 2
+    folds = [data[:split], data[split:]]
+
+    for i, fold in enumerate(folds):
+        print(f"Running fold {i}")
+        for bar in fold:
+            engine.on_bar(bar)
+
+    print("Final positions:", exec_client.positions())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()
+

--- a/tests/test_backtest_partial_fill.py
+++ b/tests/test_backtest_partial_fill.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+from quant_pipeline.backtest import run_backtest
+
+
+def test_partial_fills_reduce_turnover():
+    df = pd.DataFrame({"ret": [0.01, -0.02, 0.03, -0.01], "volume": [1, 1, 1, 1]})
+    full = run_backtest(df, return_metrics=True)
+    partial = run_backtest(df, return_metrics=True, max_volume_frac=0.25)
+    assert partial["turnover"] <= full["turnover"]

--- a/tests/test_signal_ensemble.py
+++ b/tests/test_signal_ensemble.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from quant_pipeline.ensemble import SignalEnsemble
+
+
+def test_blend_combines_signals():
+    ens = SignalEnsemble({})
+    blended = ens.blend(
+        {"a": np.array([1.0, -1.0]), "b": np.array([0.0, 1.0])},
+        weights={"a": 0.5, "b": 0.5},
+    )
+    assert np.allclose(blended, np.array([0.5, 0.0]))


### PR DESCRIPTION
## Summary
- add TradingEngine core that links features, model, risk, and execution
- implement ExecutionClient interface with simulated and broker variants
- provide simple RiskManager and example backtest/walk-forward runners

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2127b42ac832d895dd6c12611e2c4