### PR TITLE
Add strategy interface and risk parity utilities

### DIFF
--- a/src/quant_pipeline/__init__.py
+++ b/src/quant_pipeline/__init__.py
@@ -1,4 +1,8 @@
 """Core package for quant-pipeline."""
 
-__all__ = ["__version__"]
+from .strategy import Strategy
+from .simple_lstm import SimpleLSTM
+from .moving_average import MovingAverageStrategy
+
+__all__ = ["__version__", "Strategy", "SimpleLSTM", "MovingAverageStrategy"]
 __version__ = "0.1.0"

--- a/src/quant_pipeline/ensemble.py
+++ b/src/quant_pipeline/ensemble.py
@@ -88,5 +88,35 @@ class SignalEnsemble:
             raise ValueError("no overlapping signals and weights")
         return blended
 
+    def blend_multi(
+        self,
+        signals: Mapping[str, Mapping[str, Mapping[str, np.ndarray | float]]],
+        *,
+        model_weights: Mapping[str, float],
+        horizon_weights: Mapping[str, float],
+    ) -> Dict[str, np.ndarray]:
+        """Blend signals across symbols and horizons."""
+
+        out: Dict[str, np.ndarray] = {}
+        for symbol, horizons in signals.items():
+            blended_h: np.ndarray | None = None
+            total_w = 0.0
+            for horizon, sigs in horizons.items():
+                if horizon not in horizon_weights:
+                    continue
+                model_blend = self.blend(sigs, weights=model_weights)
+                w = horizon_weights[horizon]
+                total_w += w
+                blended_h = (
+                    model_blend * w
+                    if blended_h is None
+                    else blended_h + model_blend * w
+                )
+            if blended_h is not None and total_w > 0:
+                out[symbol] = blended_h / total_w
+        if not out:
+            raise ValueError("no blended signals produced")
+        return out
+
 
 __all__ = ["SignalEnsemble"]

--- a/src/quant_pipeline/moving_average.py
+++ b/src/quant_pipeline/moving_average.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Simple moving average crossover strategy."""
+
+import numpy as np
+import pandas as pd
+
+from .strategy import Strategy
+
+
+class MovingAverageStrategy(Strategy):
+    """Generates +1/-1 signal based on moving average crossover."""
+
+    def __init__(self, short_window: int = 3, long_window: int = 5) -> None:
+        if short_window <= 0 or long_window <= 0:
+            raise ValueError("windows must be positive")
+        if short_window >= long_window:
+            raise ValueError("short_window must be < long_window")
+        self.short_window = short_window
+        self.long_window = long_window
+
+    def predict(self, prices: pd.Series | np.ndarray) -> np.ndarray:
+        arr = np.asarray(prices, dtype=float)
+        if arr.ndim != 1 or len(arr) < self.long_window:
+            raise ValueError("not enough data for moving averages")
+        s = pd.Series(arr)
+        short = s.rolling(self.short_window).mean()
+        long = s.rolling(self.long_window).mean()
+        signal = np.where(short > long, 1.0, -1.0)
+        return signal[self.long_window - 1 :]
+
+
+__all__ = ["MovingAverageStrategy"]

--- a/src/quant_pipeline/simple_lstm.py
+++ b/src/quant_pipeline/simple_lstm.py
@@ -10,8 +10,10 @@ import pandas as pd
 import torch
 from torch import Tensor, nn
 
+from .strategy import Strategy
 
-class SimpleLSTM(nn.Module):
+
+class SimpleLSTM(nn.Module, Strategy):
     """Tiny LSTM network keeping state across calls.
 
     The model is purposely minimal but uses a real :class:`~torch.nn.LSTM`
@@ -99,7 +101,7 @@ class SimpleLSTM(nn.Module):
         # reset hidden state so future predictions start fresh
         self.hidden = None
 
-    def predict(self, feats: pd.DataFrame | np.ndarray) -> list[float]:
+    def predict(self, feats: pd.DataFrame | np.ndarray) -> np.ndarray:
         """Generate prediction for a window of features."""
 
         if isinstance(feats, pd.DataFrame):
@@ -114,7 +116,7 @@ class SimpleLSTM(nn.Module):
         # detach hidden state so it can be serialised
         if isinstance(self.hidden, tuple):
             self.hidden = tuple(h.detach() for h in self.hidden)
-        return pred.view(-1).tolist()
+        return pred.view(-1).cpu().numpy()
 
 
 __all__ = ["SimpleLSTM"]

--- a/src/quant_pipeline/strategy.py
+++ b/src/quant_pipeline/strategy.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Common strategy interface."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+import numpy as np
+
+
+class Strategy(ABC):
+    """Base class for all signal generating strategies."""
+
+    @abstractmethod
+    def predict(self, X: Any) -> np.ndarray:
+        """Return model signals as a numpy array."""
+        raise NotImplementedError
+
+
+__all__ = ["Strategy"]

--- a/src/quant_pipeline/weights_store.py
+++ b/src/quant_pipeline/weights_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Persistence of strategy weights in SQLite."""
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, Mapping
+
+
+def save_weights(db_path: str | Path, weights: Mapping[str, Mapping[str, Mapping[str, float]]]) -> None:
+    """Persist nested weight mapping to a SQLite database."""
+
+    path = Path(db_path)
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS weights(
+            strategy TEXT,
+            symbol TEXT,
+            horizon TEXT,
+            weight REAL,
+            PRIMARY KEY(strategy, symbol, horizon)
+        )
+        """
+    )
+    for strat, symbols in weights.items():
+        for symbol, horizons in symbols.items():
+            for horizon, w in horizons.items():
+                cur.execute(
+                    "REPLACE INTO weights(strategy, symbol, horizon, weight) VALUES (?, ?, ?, ?)",
+                    (strat, symbol, horizon, float(w)),
+                )
+    conn.commit()
+    conn.close()
+
+
+def load_weights(db_path: str | Path) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Load weights from ``db_path``."""
+
+    path = Path(db_path)
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS weights(
+            strategy TEXT,
+            symbol TEXT,
+            horizon TEXT,
+            weight REAL,
+            PRIMARY KEY(strategy, symbol, horizon)
+        )
+        """
+    )
+    rows = cur.execute("SELECT strategy, symbol, horizon, weight FROM weights").fetchall()
+    conn.close()
+    out: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for strat, symbol, horizon, w in rows:
+        out.setdefault(strat, {}).setdefault(symbol, {})[horizon] = float(w)
+    return out
+
+
+__all__ = ["save_weights", "load_weights"]

--- a/tests/test_multi_horizon_ensemble.py
+++ b/tests/test_multi_horizon_ensemble.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from quant_pipeline.ensemble import SignalEnsemble
+
+
+def test_blend_multi_horizon_symbol():
+    ens = SignalEnsemble({})
+    signals = {
+        "BTC": {
+            "h1": {"a": np.array([1.0, 0.0]), "b": np.array([0.0, 1.0])},
+            "h2": {"a": np.array([0.5, 0.5]), "b": np.array([-0.5, -0.5])},
+        }
+    }
+    out = ens.blend_multi(
+        signals,
+        model_weights={"a": 0.5, "b": 0.5},
+        horizon_weights={"h1": 0.7, "h2": 0.3},
+    )
+    assert set(out) == {"BTC"}
+    assert out["BTC"].shape == (2,)

--- a/tests/test_risk_parity.py
+++ b/tests/test_risk_parity.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from quant_pipeline.risk import risk_parity_weights, rolling_covariance
+
+
+def test_risk_parity_weights_sum_to_one():
+    cov = np.array([[0.04, 0.006], [0.006, 0.09]])
+    w = risk_parity_weights(cov)
+    assert np.isclose(w.sum(), 1.0)
+    assert np.all(w > 0)
+
+
+def test_rolling_covariance_recent_window():
+    returns = np.array([
+        [0.01, 0.02],
+        [-0.01, 0.03],
+        [0.02, -0.02],
+        [0.0, 0.01],
+    ])
+    import pandas as pd
+
+    df = pd.DataFrame(returns, columns=["a", "b"])
+    cov = rolling_covariance(df, window=3)
+    assert cov.shape == (2, 2)

--- a/tests/test_strategy_interface.py
+++ b/tests/test_strategy_interface.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from quant_pipeline.simple_lstm import SimpleLSTM
+from quant_pipeline.moving_average import MovingAverageStrategy
+
+
+def test_strategies_share_predict_interface():
+    data = pd.DataFrame({"ret": [0.1, -0.2, 0.05, 0.1, -0.05]})
+    lstm = SimpleLSTM(input_size=1, hidden_size=2)
+    lstm.fit(data, epochs=1, lr=0.01)
+    ma = MovingAverageStrategy()
+    lstm_signal = lstm.predict(data)
+    ma_signal = ma.predict(data["ret"])
+    assert len(lstm_signal) == 1
+    assert ma_signal.ndim == 1

--- a/tests/test_weights_store.py
+++ b/tests/test_weights_store.py
@@ -1,0 +1,9 @@
+from quant_pipeline.weights_store import save_weights, load_weights
+
+
+def test_save_and_load_weights(tmp_path):
+    path = tmp_path / "w.db"
+    weights = {"strat1": {"BTC": {"h1": 0.5}}}
+    save_weights(path, weights)
+    loaded = load_weights(path)
+    assert loaded == weights


### PR DESCRIPTION
## Summary
- add abstract `Strategy` base class and moving average implementation
- support multi-symbol, multi-horizon blending in `SignalEnsemble`
- provide rolling covariance, risk-parity weights, and SQLite weight persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b232c903d0832d9be52cffcfaa4b06