### PR TITLE
feat: add live hooks and calibration logging

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -34,6 +34,9 @@ class TradingEngine:
     def on_bar(self, market_data: Any) -> Optional[str]:
         """Process one market data event and optionally send an order."""
 
+        self.risk_manager.update_price(
+            getattr(market_data, "symbol", ""), getattr(market_data, "price", 0.0)
+        )
         features = self.feature_builder(market_data)
         signal = float(self.model.predict(features))
         qty = self.size_fn(signal)

--- a/src/live_runner.py
+++ b/src/live_runner.py
@@ -1,0 +1,31 @@
+"""Minimal live trading runner using the unified engine."""
+from __future__ import annotations
+
+import yaml
+
+from engine import TradingEngine
+from execution import CostModel, BrokerExecutionClient
+from risk import RiskLimits, RiskManager
+from bt_runner import DummyModel, build_features
+
+
+def main(cfg_path: str = "config.yaml") -> None:
+    cfg = yaml.safe_load(open(cfg_path))
+    risk = RiskManager(RiskLimits(max_position=cfg["risk"]["max_position"]))
+    cost = CostModel(**cfg["execution"])
+    exec_client = BrokerExecutionClient(cost_model=cost)
+    engine = TradingEngine(DummyModel(), build_features, risk, exec_client)
+
+    data = [
+        {"symbol": "XYZ", "price": 100.0, "ma": 100.0},
+        {"symbol": "XYZ", "price": 101.0, "ma": 100.5},
+        {"symbol": "XYZ", "price": 99.5, "ma": 100.5},
+    ]
+    for bar in data:
+        engine.on_bar(bar)
+
+    print("Final positions:", exec_client.positions())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/src/quant_pipeline/walkforward.py
+++ b/src/quant_pipeline/walkforward.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
-from sklearn.calibration import CalibratedClassifierCV
+from sklearn.calibration import CalibratedClassifierCV, calibration_curve
 
 from .model_registry import ModelRegistry
 
@@ -110,6 +110,13 @@ def walkforward(
         if calibrate and hasattr(model, "predict_proba"):
             # Only attempt probability calibration for classification models.
             model = _calibrate(model, X_train, y_train, calibrate)
+            if registry and model_id is not None:
+                prob_true, prob_pred = calibration_curve(
+                    y_train, model.predict_proba(X_train)[:, 1], n_bins=10, strategy="quantile"
+                )
+                registry.log_calibration_curve(
+                    model_id, prob_true=prob_true.tolist(), prob_pred=prob_pred.tolist()
+                )
 
         y_prob = model.predict_proba(X_test)[:, 1]
         metric = metric_func(y_test, y_prob)

--- a/src/risk.py
+++ b/src/risk.py
@@ -18,6 +18,8 @@ class RiskLimits:
     """Configuration for simple notional limits."""
 
     max_position: float = 0.0  # absolute quantity limit per symbol
+    trailing_pct: float = 0.0  # trailing stop expressed as fraction
+    max_drawdown: float = 0.0  # hard kill-switch based on drawdown
 
 
 class RiskManager:
@@ -30,13 +32,34 @@ class RiskManager:
 
     def __init__(self, limits: RiskLimits):
         self.limits = limits
+        self._entry: Dict[str, float] = {}
+        self._high_water: Dict[str, float] = {}
+        self._kill = False
+
+    def update_price(self, symbol: str, price: float) -> None:
+        """Update trailing stop and drawdown checks with latest price."""
+
+        if symbol in self._entry:
+            self._high_water[symbol] = max(self._high_water.get(symbol, price), price)
+            if self.limits.trailing_pct > 0:
+                stop = self._high_water[symbol] * (1 - self.limits.trailing_pct)
+                if price <= stop:
+                    self._kill = True
+            if self.limits.max_drawdown > 0:
+                drawdown = (
+                    self._high_water[symbol] - price
+                ) / self._high_water[symbol]
+                if drawdown >= self.limits.max_drawdown:
+                    self._kill = True
 
     # ------------------------------------------------------------------
     # Hooks called by the engine
     # ------------------------------------------------------------------
     def pre_trade(self, order: Order, positions: Dict[str, float]) -> bool:
-        """Return ``True`` if the order respects position limits."""
+        """Return ``True`` if the order respects risk limits."""
 
+        if self._kill:
+            return False
         current = positions.get(order.symbol, 0.0)
         proposed = current + order.qty
         if abs(proposed) > self.limits.max_position:
@@ -51,6 +74,18 @@ class RiskManager:
         version simply exists so the engine has a stable callback point.
         """
 
-        # No-op for now, reserved for future extensions.
-        return
+        current = positions.get(order.symbol, 0.0)
+        if current == 0:
+            self._entry.pop(order.symbol, None)
+            self._high_water.pop(order.symbol, None)
+        else:
+            price = order.price or 0.0
+            if order.symbol not in self._entry:
+                self._entry[order.symbol] = price
+                self._high_water[order.symbol] = price
+
+    def reset_kill(self) -> None:
+        """Reset kill-switch allowing trading again."""
+
+        self._kill = False
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,12 @@
+from execution import BrokerExecutionClient, CostModel, Order
+
+
+def test_broker_cancel_on_disconnect(capsys):
+    client = BrokerExecutionClient(cost_model=CostModel())
+    o1 = Order(symbol="XYZ", qty=1, price=100.0)
+    o2 = Order(symbol="XYZ", qty=-1, price=101.0)
+    client.send(o1)
+    client.send(o2)
+    assert len(client._orders) == 2
+    client.handle_disconnect()
+    assert len(client._orders) == 0

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,13 @@
+from risk import RiskLimits, RiskManager
+from execution import Order
+
+
+def test_trailing_stop_kill_switch():
+    limits = RiskLimits(max_position=1, trailing_pct=0.1, max_drawdown=0.2)
+    rm = RiskManager(limits)
+    order = Order(symbol="XYZ", qty=1, price=100.0)
+    rm.post_trade(order, {"XYZ": 1})
+    rm.update_price("XYZ", 105.0)
+    assert not rm._kill
+    rm.update_price("XYZ", 93.0)
+    assert rm._kill

--- a/tests/test_walkforward.py
+++ b/tests/test_walkforward.py
@@ -45,3 +45,6 @@ def test_walkforward_logs_oos_and_stability(tmp_path):
     metrics = json.loads(first["metrics_json"])
     assert "coef" in params
     assert "metric" in metrics
+
+    calib_rows = reg.list_calibration_curves(model_id)
+    assert len(calib_rows) == 3


### PR DESCRIPTION
## Summary
- track fees and cancel on disconnect in `BrokerExecutionClient`
- store and expose calibration curves in the model registry and walk-forward helper
- extend risk manager with trailing stops and drawdown kill switch
- add minimal live runner using unified engine

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22fbd9d68832d825571887d11f5f3