### PR TITLE
feat: add horizon blending for training labels

### DIFF
--- a/src/quant_pipeline/ensemble.py
+++ b/src/quant_pipeline/ensemble.py
@@ -23,6 +23,37 @@ from typing import Dict, Mapping
 import numpy as np
 
 
+def blend_horizons(signals: Dict[int, np.ndarray | float]) -> np.ndarray:
+    """Blend signals coming from different forecast horizons.
+
+    Each entry in ``signals`` maps a horizon (in bars) to the signal produced
+    for that horizon.  The horizons are combined using weights inversely
+    proportional to their length so that nearer horizons carry more influence.
+
+    Parameters
+    ----------
+    signals
+        Mapping from horizon to already computed signal values.  Values may be
+        scalars or NumPy arrays and must all share the same shape.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted blend of the provided signals.
+    """
+
+    if not signals:
+        raise ValueError("signals must not be empty")
+
+    weights = {h: 1.0 / float(h) for h in signals}
+    total = sum(weights.values())
+    blended = None
+    for h, sig in signals.items():
+        arr = np.asarray(sig, dtype=float)
+        w = weights[h] / total
+        blended = arr * w if blended is None else blended + arr * w
+    return blended
+
 class SignalEnsemble:
     """Blend signals from multiple models.
 
@@ -89,4 +120,4 @@ class SignalEnsemble:
         return blended
 
 
-__all__ = ["SignalEnsemble"]
+__all__ = ["SignalEnsemble", "blend_horizons"]

--- a/src/quant_pipeline/training.py
+++ b/src/quant_pipeline/training.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Any, Callable, Dict, Iterator, Tuple
+from typing import Any, Callable, Dict, Iterator, Tuple, Sequence
 
 from concurrent.futures import ThreadPoolExecutor
 import json
@@ -18,6 +18,7 @@ from .datasets import make_lstm_windows
 from .model_registry import ModelRegistry
 from .labeling import forward_return, triple_barrier_labels
 from .backtest import run_backtest
+from .ensemble import blend_horizons
 from .genetic import GeneticOptimizer
 
 logger = logging.getLogger(__name__)
@@ -138,7 +139,7 @@ class AutoTrainer:
         seq_len: int = 10,
         cv_splits: int = 5,
         embargo: int = 0,
-        label_horizon: int | None = None,
+        label_horizon: int | Sequence[int] | None = None,
         label_up_mult: float = 1.0,
         label_down_mult: float = 1.0,
         label_type: str = "triple_barrier",
@@ -201,17 +202,28 @@ class AutoTrainer:
         df = self.dataset_loader(self.history_days)
         if self.label_horizon is not None:
             df = df.copy()
+            horizons: Sequence[int]
+            if isinstance(self.label_horizon, Sequence) and not isinstance(
+                self.label_horizon, (str, bytes)
+            ):
+                horizons = list(self.label_horizon)
+            else:
+                horizons = [int(self.label_horizon)]
+
+            signals: Dict[int, np.ndarray]
             if self.label_type == "forward_return":
-                df["label"] = forward_return(df, self.label_horizon)
+                signals = {h: forward_return(df, h) for h in horizons}
             elif self.label_type == "triple_barrier":
-                df["label"] = triple_barrier_labels(
-                    df,
-                    self.label_up_mult,
-                    self.label_down_mult,
-                    self.label_horizon,
-                )
+                signals = {
+                    h: triple_barrier_labels(
+                        df, self.label_up_mult, self.label_down_mult, h
+                    )
+                    for h in horizons
+                }
             else:
                 raise ValueError(f"unknown label_type {self.label_type}")
+
+            df["label"] = blend_horizons(signals)
 
         if "label" in df.columns:
             dataset = self.prepare_dataset(df)

--- a/tests/test_horizon_blending.py
+++ b/tests/test_horizon_blending.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pandas as pd
+
+from quant_pipeline.ensemble import blend_horizons
+from quant_pipeline.labeling import forward_return
+from quant_pipeline.model_registry import ModelRegistry
+from quant_pipeline.training import AutoTrainer
+
+
+def test_blend_horizons_weights():
+    signals = {1: np.array([1.0, 2.0, 3.0]), 2: np.array([2.0, 2.0, 2.0])}
+    blended = blend_horizons(signals)
+    # weights: 1 for h=1, 0.5 for h=2 -> normalised 2/3 and 1/3
+    expected = np.array([
+        1.0 * 2 / 3 + 2.0 * 1 / 3,
+        2.0 * 2 / 3 + 2.0 * 1 / 3,
+        3.0 * 2 / 3 + 2.0 * 1 / 3,
+    ])
+    assert np.allclose(blended, expected)
+
+
+def test_autotrainer_multihorizon_label(tmp_path):
+    df = pd.DataFrame({"close": np.linspace(1, 6, 6)})
+    reg = ModelRegistry(str(tmp_path / "reg.db"))
+
+    captured = {}
+
+    def loader(_):
+        return df
+
+    def train_model(data):
+        X, y, _ = data
+        captured["y"] = y
+        return {}
+
+    trainer = AutoTrainer(
+        reg,
+        train_every_bars=1,
+        history_days=1,
+        max_challengers=1,
+        dataset_loader=loader,
+        train_model=train_model,
+        seq_len=2,
+        label_horizon=[1, 2],
+        label_type="forward_return",
+    )
+
+    trainer._train_cycle()
+
+    expected = blend_horizons({
+        1: forward_return(df, 1),
+        2: forward_return(df, 2),
+    })
+    assert np.allclose(captured["y"], expected[2:], equal_nan=True)


### PR DESCRIPTION
## Summary
- add `blend_horizons` to combine signals across different forecast horizons with inverse weighting
- allow AutoTrainer to compute labels for multiple horizons and blend them before training
- cover horizon blending with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22cac7530832daddebd1daad90fb7