### PR TITLE
feat: add trailing stop management

### DIFF
--- a/src/quant_pipeline/risk.py
+++ b/src/quant_pipeline/risk.py
@@ -126,6 +126,8 @@ class RiskManager:
         tp_atr: float = 6.0,
         atr_window: int = 14,
         regime_reduction: float = 0.5,
+        trailing_on: bool = False,
+        trailing_mult: float = 0.02,
     ) -> None:
         self.max_dd_daily = max_dd_daily
         self.max_dd_weekly = max_dd_weekly
@@ -145,6 +147,11 @@ class RiskManager:
         self.tp_atr = tp_atr
         self.atr_window = atr_window
         self.regime_reduction = regime_reduction
+        self.trailing_on = trailing_on
+        self.trailing_mult = trailing_mult
+        self.trailing_stop: Optional[float] = None
+        self._trail_price: Optional[float] = None
+        self._current_position: float = 0.0
         self.pause_until: Optional[datetime] = None
         self._daily_dd = 0.0
         self._weekly_dd = 0.0
@@ -259,6 +266,31 @@ class RiskManager:
         kelly *= self.kelly_fraction
         return kelly * (self.target_volatility / sigma)
 
+    def update_trailing(self, price: float) -> float | None:
+        """Update trailing stop based on a favorable price move.
+
+        The method maintains the highest price reached for long positions
+        and the lowest for shorts.  The stop follows the extreme by
+        ``trailing_mult`` percent.
+        """
+
+        if not self.trailing_on or self._current_position == 0:
+            return self.trailing_stop
+
+        if self._current_position > 0:
+            if self._trail_price is None or price > self._trail_price:
+                self._trail_price = price
+            new_stop = self._trail_price * (1 - self.trailing_mult)
+            if self.trailing_stop is None or new_stop > self.trailing_stop:
+                self.trailing_stop = new_stop
+        else:
+            if self._trail_price is None or price < self._trail_price:
+                self._trail_price = price
+            new_stop = self._trail_price * (1 + self.trailing_mult)
+            if self.trailing_stop is None or new_stop < self.trailing_stop:
+                self.trailing_stop = new_stop
+        return self.trailing_stop
+
     def target_position(
         self,
         prob: float,
@@ -286,6 +318,21 @@ class RiskManager:
         regime = exposure_limits.get("regime")
         current_pos = float(exposure_limits.get("current_position", 0.0))
         total_notional = float(exposure_limits.get("total_notional", 0.0))
+
+        if self.trailing_on:
+            self._current_position = current_pos
+            if current_pos == 0:
+                self.trailing_stop = None
+                self._trail_price = None
+            else:
+                self.update_trailing(price)
+                if self.trailing_stop is not None:
+                    hit_long = current_pos > 0 and price <= self.trailing_stop
+                    hit_short = current_pos < 0 and price >= self.trailing_stop
+                    if hit_long or hit_short:
+                        self.trailing_stop = None
+                        self._trail_price = None
+                        return 0.0
 
         # Base Kelly position scaled to target volatility
         target = self.kelly_position(mu=prob, sigma=sigma)

--- a/src/risk.py
+++ b/src/risk.py
@@ -8,7 +8,7 @@ that backtest, walk-forward and live modes can share the same interface.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
 
 from execution import Order
 
@@ -28,8 +28,13 @@ class RiskManager:
     more sophisticated checks (drawdown, latency, etc.).
     """
 
-    def __init__(self, limits: RiskLimits):
+    def __init__(self, limits: RiskLimits, *, trailing_on: bool = False, trailing_mult: float = 0.02):
         self.limits = limits
+        self.trailing_on = trailing_on
+        self.trailing_mult = trailing_mult
+        self.trailing_stop: Optional[float] = None
+        self._trail_price: Optional[float] = None
+        self._current_position: float = 0.0
 
     # ------------------------------------------------------------------
     # Hooks called by the engine
@@ -41,6 +46,20 @@ class RiskManager:
         proposed = current + order.qty
         if abs(proposed) > self.limits.max_position:
             return False
+
+        if self.trailing_on and order.price is not None:
+            self._current_position = current
+            if current == 0:
+                self.trailing_stop = None
+                self._trail_price = None
+            else:
+                self.update_trailing(order.price)
+                if self.trailing_stop is not None:
+                    hit_long = current > 0 and order.price <= self.trailing_stop and order.qty > 0
+                    hit_short = current < 0 and order.price >= self.trailing_stop and order.qty < 0
+                    if hit_long or hit_short:
+                        return False
+
         return True
 
     def post_trade(self, order: Order, positions: Dict[str, float]) -> None:
@@ -51,6 +70,30 @@ class RiskManager:
         version simply exists so the engine has a stable callback point.
         """
 
-        # No-op for now, reserved for future extensions.
+        if self.trailing_on:
+            current = positions.get(order.symbol, 0.0)
+            if current == 0:
+                self.trailing_stop = None
+                self._trail_price = None
         return
+
+    def update_trailing(self, price: float) -> float | None:
+        """Update trailing stop based on a favorable move."""
+
+        if not self.trailing_on or self._current_position == 0:
+            return self.trailing_stop
+
+        if self._current_position > 0:
+            if self._trail_price is None or price > self._trail_price:
+                self._trail_price = price
+            new_stop = self._trail_price * (1 - self.trailing_mult)
+            if self.trailing_stop is None or new_stop > self.trailing_stop:
+                self.trailing_stop = new_stop
+        else:
+            if self._trail_price is None or price < self._trail_price:
+                self._trail_price = price
+            new_stop = self._trail_price * (1 + self.trailing_mult)
+            if self.trailing_stop is None or new_stop < self.trailing_stop:
+                self.trailing_stop = new_stop
+        return self.trailing_stop
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -129,3 +129,20 @@ def test_load_risk_config(tmp_path):
     cfg = load_risk_config(path)
     assert cfg.max_dd_daily == 0.07
     assert cfg.pause_minutes == 5
+
+
+def test_trailing_stop_in_target_position():
+    rm = RiskManager(
+        max_dd_daily=1,
+        max_dd_weekly=1,
+        latency_threshold=100,
+        latency_window=1,
+        pause_minutes=1,
+        trailing_on=True,
+        trailing_mult=0.02,
+    )
+    exposure = {"symbol": "BTC", "current_position": 1.0, "total_notional": 0.0}
+    rm.target_position(prob=0.01, price=100.0, sigma=0.1, exposure_limits=exposure)
+    rm.target_position(prob=0.01, price=110.0, sigma=0.1, exposure_limits=exposure)
+    tgt = rm.target_position(prob=0.01, price=107.0, sigma=0.1, exposure_limits=exposure)
+    assert tgt == 0.0


### PR DESCRIPTION
## Summary
- add optional trailing stop parameters to risk manager
- implement trailing update mechanism and integrate with position targeting and pre-trade checks
- cover trailing behaviour with unit tests

## Testing
- `pytest tests/test_risk.py -q`
- `pytest tests/test_decision_loop.py tests/test_quality.py tests/test_state_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22cab722c832db9e5e42214436edf