### PR TITLE
feat: add slippage function support

### DIFF
--- a/docs/backtest.md
+++ b/docs/backtest.md
@@ -1,0 +1,24 @@
+# Backtesting
+
+The backtesting utilities allow plugging custom cost models to better
+approximate real-world trading.
+
+## Custom slippage function
+
+`CostModel` accepts a `slippage_fn` with signature
+`slippage_fn(spread, vol, volume)` returning slippage in basis points. The
+function receives the bar's spread, volatility and traded volume.
+
+```python
+from execution import CostModel
+
+# Simple example: widen slippage with spread and volatility
+
+def slippage_fn(spread: float, vol: float, volume: float) -> float:
+    return spread * 10_000 + vol * 100
+
+cost = CostModel(fee_bps=1.0, slippage_fn=slippage_fn)
+```
+
+The simulator will pass the current bar's values when computing trade
+costs.

--- a/src/engine.py
+++ b/src/engine.py
@@ -40,7 +40,14 @@ class TradingEngine:
         if qty == 0:
             return None
         side_price = getattr(market_data, "price", None)
-        order = Order(symbol=getattr(market_data, "symbol", ""), qty=qty, price=side_price)
+        order = Order(
+            symbol=getattr(market_data, "symbol", ""),
+            qty=qty,
+            price=side_price,
+            spread=getattr(market_data, "spread", 0.0),
+            vol=getattr(market_data, "volatility", 0.0),
+            volume=getattr(market_data, "volume", 0.0),
+        )
         if not self.risk_manager.pre_trade(order, self.execution_client.positions()):
             return None
         order_id = self.execution_client.send(order)


### PR DESCRIPTION
## Summary
- allow CostModel to accept custom `slippage_fn` using spread, volatility and volume
- pass current bar spread/vol/volume from `SimExecutionClient` and `TradingEngine`
- document slippage function usage in backtest guide

## Testing
- `pytest tests/test_execution_smoke.py -q`
- `pytest tests/test_backtest_enhancements.py -q`
- `pytest tests/test_decision_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22ca44e0c832db7aa4e4eeb28fa93