### PR TITLE
Add fills and PnL tracking with MLflow logging

### DIFF
--- a/src/quant_pipeline/model_registry.py
+++ b/src/quant_pipeline/model_registry.py
@@ -12,6 +12,11 @@ from typing import Callable, Dict, List, Optional
 
 import numpy as np
 
+try:  # optional MLflow integration
+    import mlflow  # type: ignore
+except Exception:  # pragma: no cover - mlflow is optional
+    mlflow = None  # type: ignore
+
 
 @dataclass
 class ModelRecord:
@@ -173,6 +178,11 @@ class ModelRegistry:
                 (model_id, ts, ret, sharpe),
             )
             self.conn.commit()
+        if mlflow is not None:
+            if ts is None:
+                mlflow.log_metric(f"pnl_model_{model_id}", ret)
+            else:
+                mlflow.log_metric(f"pnl_model_{model_id}", ret, step=ts)
 
     def log_oos_metrics(
         self,

--- a/tests/test_ledger_extra.py
+++ b/tests/test_ledger_extra.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from trading import ledger
+
+
+def test_record_fill_and_pnl(tmp_path):
+    ledger.clear()
+    day = date(2024, 1, 1)
+    ledger.record_fill("oid1", "AAPL", qty=10, price=5.0, day=day, note="test")
+    ledger.record_pnl(100.0, day=day, model="m1")
+    conn = ledger._connection()
+    fill_rows = conn.execute("SELECT order_id, ticker, qty, price, usd, day, note FROM fills").fetchall()
+    pnl_rows = conn.execute("SELECT day, pnl, model FROM pnl").fetchall()
+    assert fill_rows[0]["order_id"] == "oid1"
+    assert fill_rows[0]["usd"] == 50.0
+    assert pnl_rows[0]["pnl"] == 100.0
+    assert pnl_rows[0]["model"] == "m1"
+    ledger.clear()
+    assert conn.execute("SELECT COUNT(*) FROM fills").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM pnl").fetchone()[0] == 0

--- a/tests/test_model_registry_mlflow.py
+++ b/tests/test_model_registry_mlflow.py
@@ -1,0 +1,28 @@
+import quant_pipeline.model_registry as mr
+from quant_pipeline.model_registry import ModelRegistry
+
+
+def test_log_perf_mlflow(monkeypatch, tmp_path):
+    db = tmp_path / "reg.db"
+    reg = ModelRegistry(str(db))
+
+    logged = {}
+
+    class DummyMlflow:
+        def log_metric(self, name, value, step=None):
+            logged[name] = (value, step)
+
+    monkeypatch.setattr(mr, "mlflow", DummyMlflow())
+
+    art = tmp_path / "a.bin"
+    calib = tmp_path / "a.calib"
+    art.write_text("a")
+    calib.write_text("b")
+    mid = reg.register_model(
+        model_type="ml",
+        genes_json="{}",
+        artifact_path=str(art),
+        calib_path=str(calib),
+    )
+    reg.log_perf(mid, ret=1.23, sharpe=0.0, ts=5)
+    assert logged[f"pnl_model_{mid}"] == (1.23, 5)


### PR DESCRIPTION
## Summary
- track trade fills and daily PnL in new SQLite tables and helpers
- expose ledger utilities `record_fill` and `record_pnl`
- optionally log per-model PnL metrics via MLflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b22ca1de8c832dbd7cad1f3a4e455b