### PR TITLE
Add model adapters and signal ensemble

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,12 @@
+"""Light-weight model adapters and ensemble utilities.
+
+This package groups small helpers used across the repository when a full
+blown ML framework would be overkill.  The modules intentionally keep the
+API surface minimal.
+"""
+
+from .xgb_adapter import XGBoostAdapter
+from .tcn_adapter import TCNAdapter
+from .ensemble import Signal, SignalEnsemble
+
+__all__ = ["XGBoostAdapter", "TCNAdapter", "Signal", "SignalEnsemble"]

--- a/models/ensemble.py
+++ b/models/ensemble.py
@@ -1,0 +1,73 @@
+"""Tools for combining model signals.
+
+This module defines :class:`Signal`, a small data container describing a
+model output together with its associated quality metrics, and
+:class:`SignalEnsemble` which aggregates signals from different horizons
+using a weighted average based on confidence and calibration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+import numpy as np
+
+
+@dataclass
+class Signal:
+    """Representation of a model prediction.
+
+    Parameters
+    ----------
+    value:
+        Predicted value or signal strength.
+    confidence:
+        Value between 0 and 1 expressing how confident the model is in the
+        prediction.  Defaults to ``1.0``.
+    calibration:
+        Calibration score of the model.  Defaults to ``1.0``.
+    """
+
+    value: float
+    confidence: float = 1.0
+    calibration: float = 1.0
+
+    @property
+    def weight(self) -> float:
+        """Weight contribution derived from confidence and calibration."""
+
+        return self.confidence * self.calibration
+
+
+class SignalEnsemble:
+    """Combine signals from multiple time horizons.
+
+    The ensemble expects a mapping containing the horizons ``h1m``, ``h5m``
+    and ``h60m`` by default.  Each value should be a :class:`Signal` instance.
+    The combined output is a weighted average where weights are the product
+    of each signal's confidence and calibration.
+    """
+
+    def __init__(self, horizons: Iterable[str] | None = None) -> None:
+        self.horizons = list(horizons) if horizons is not None else ["h1m", "h5m", "h60m"]
+
+    def combine(self, signals: Mapping[str, Signal]) -> float:
+        """Blend the provided signals into a single value."""
+
+        weights = []
+        values = []
+        for h in self.horizons:
+            if h not in signals:
+                raise KeyError(f"missing signal for horizon {h}")
+            sig = signals[h]
+            w = sig.weight
+            weights.append(w)
+            values.append(sig.value)
+        total = float(np.sum(weights))
+        if total == 0:
+            raise ValueError("total weight is zero")
+        return float(np.dot(values, weights) / total)
+
+
+__all__ = ["Signal", "SignalEnsemble"]

--- a/models/tcn_adapter.py
+++ b/models/tcn_adapter.py
@@ -1,0 +1,94 @@
+"""Temporal Convolutional Network (TCN) adapter.
+
+The implementation is intentionally compact and focuses on exposing an easy to
+use ``fit``/``predict`` interface.  It relies only on PyTorch and is suitable
+for tiny experimental datasets rather than production use.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import torch
+from torch import nn
+
+from .ensemble import Signal
+
+
+class _SimpleTCN(nn.Module):
+    """Very small TCN made of two causal convolution layers."""
+
+    def __init__(self, input_size: int, channels: int, kernel_size: int) -> None:
+        super().__init__()
+        padding = (kernel_size - 1)
+        self.conv1 = nn.Conv1d(
+            input_size, channels, kernel_size, padding=padding, dilation=1
+        )
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv1d(
+            channels, channels, kernel_size, padding=padding, dilation=2
+        )
+        self.fc = nn.Linear(channels, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.conv1(x)
+        out = self.relu(out)
+        out = self.conv2(out)
+        return self.fc(out[:, :, -1])
+
+
+class TCNAdapter(nn.Module):
+    """Adapter exposing ``fit`` and ``predict`` for a tiny TCN."""
+
+    def __init__(
+        self,
+        *,
+        input_size: int = 1,
+        channels: int = 8,
+        kernel_size: int = 2,
+    ) -> None:
+        super().__init__()
+        self.model = _SimpleTCN(input_size, channels, kernel_size)
+        self.input_size = input_size
+
+    def fit(
+        self,
+        X: np.ndarray | Sequence[Sequence[float]],
+        y: Sequence[float],
+        *,
+        epochs: int = 20,
+        lr: float = 0.001,
+    ) -> None:
+        """Train the network using mean squared error."""
+
+        x_arr = np.asarray(X, dtype=float)
+        y_arr = np.asarray(y, dtype=float)
+        if x_arr.ndim != 3 or x_arr.shape[2] != self.input_size:
+            raise ValueError("X must have shape (n_samples, seq_len, input_size)")
+        x = torch.tensor(x_arr, dtype=torch.float32).transpose(1, 2)
+        t = torch.tensor(y_arr, dtype=torch.float32).view(-1, 1)
+
+        opt = torch.optim.Adam(self.parameters(), lr=lr)
+        loss_fn = nn.MSELoss()
+
+        for _ in range(epochs):
+            opt.zero_grad()
+            pred = self.model(x)
+            loss = loss_fn(pred, t)
+            loss.backward()
+            opt.step()
+
+    def predict(self, X: np.ndarray | Sequence[Sequence[float]]) -> list[Signal]:
+        """Return predictions as :class:`Signal` objects."""
+
+        x_arr = np.asarray(X, dtype=float)
+        if x_arr.ndim != 3 or x_arr.shape[2] != self.input_size:
+            raise ValueError("X must have shape (n_samples, seq_len, input_size)")
+        x = torch.tensor(x_arr, dtype=torch.float32).transpose(1, 2)
+        with torch.no_grad():
+            pred = self.model(x).view(-1).tolist()
+        return [Signal(float(p)) for p in pred]
+
+
+__all__ = ["TCNAdapter"]

--- a/models/xgb_adapter.py
+++ b/models/xgb_adapter.py
@@ -1,0 +1,48 @@
+"""Adapter wrapping XGBoost models.
+
+The adapter exposes a very small API mirroring the parts of the scikit-learn
+interface that are required within the project.  Predictions are returned as
+:class:`~models.ensemble.Signal` objects so they can be fed directly into
+:class:`~models.ensemble.SignalEnsemble`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from xgboost import XGBRegressor
+except Exception:  # pragma: no cover - handled gracefully
+    XGBRegressor = None  # type: ignore
+
+from .ensemble import Signal
+
+
+class XGBoostAdapter:
+    """Light-weight wrapper around :class:`xgboost.XGBRegressor`."""
+
+    def __init__(self, **model_kwargs: Any) -> None:
+        if XGBRegressor is None:  # pragma: no cover - only triggers if missing
+            raise ImportError("xgboost is required for XGBoostAdapter")
+        self.model = XGBRegressor(**model_kwargs)
+
+    def fit(
+        self,
+        X: np.ndarray | Sequence[Sequence[float]],
+        y: Sequence[float],
+        **kwargs: Any,
+    ) -> None:
+        """Fit the underlying model."""
+
+        self.model.fit(np.asarray(X), np.asarray(y), **kwargs)
+
+    def predict(self, X: np.ndarray | Sequence[Sequence[float]]) -> list[Signal]:
+        """Generate :class:`Signal` objects for feature matrix ``X``."""
+
+        preds = self.model.predict(np.asarray(X))
+        return [Signal(float(p)) for p in np.atleast_1d(preds)]
+
+
+__all__ = ["XGBoostAdapter"]


### PR DESCRIPTION
## Summary
- implement Signal/SignalEnsemble to blend h1m, h5m and h60m horizons using confidence/calibration weights
- add XGBoostAdapter emitting standard Signal objects
- introduce PyTorch-based TCNAdapter with simple training and prediction helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b224f0802c832dbf77197b863c588e