### PR TITLE
Add heartbeat and reconnection logic to BrokerExecutionClient

### DIFF
--- a/src/execution.py
+++ b/src/execution.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+import threading
 from typing import Dict, List, Optional
 import uuid
+
+from quant_pipeline.observability import Observability
 
 
 # ---------------------------------------------------------------------------
@@ -138,24 +141,81 @@ class SimExecutionClient(ExecutionClient):
 
 
 class BrokerExecutionClient(ExecutionClient):
-    """Placeholder implementation for live trading.
+    """Minimal live-trading client with heartbeat and reconnect logic."""
 
-    In a production system this class would wrap a library such as CCXT,
-    IBKR, or a broker SDK.  The methods currently log their usage making
-    it easy to later plug in the real API calls.
-    """
-
-    def __init__(self):
+    def __init__(self, observability: Observability | None = None, heartbeat_interval: float = 5.0):
         self._positions: Dict[str, float] = {}
+        self.obs = observability or Observability()
+        self._heartbeat_interval = heartbeat_interval
+        self._pending_orders: Dict[str, Order] = {}
+        self._connected = False
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self.connect()
+        if heartbeat_interval > 0:
+            self._thread.start()
 
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+    def connect(self) -> None:
+        """Establish connection to the broker (placeholder)."""
+
+        self._connected = True
+
+    def _ping(self) -> bool:  # pragma: no cover - simple stub
+        """Heartbeat check to broker API."""
+
+        return True
+
+    def check_connection(self) -> None:
+        """Verify connection and handle disconnects."""
+
+        ok = False
+        try:
+            ok = self._ping()
+        except Exception:
+            ok = False
+        if not ok:
+            self._connected = False
+            self.obs.alert_connection_failure("broker")
+            self._cancel_all_pending()
+            self.connect()
+        else:
+            self._connected = True
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._heartbeat_interval):
+            self.obs.heartbeat()
+            self.check_connection()
+
+    def close(self) -> None:
+        """Stop heartbeat thread."""
+
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join()
+
+    def _cancel_all_pending(self) -> None:
+        for oid in list(self._pending_orders):
+            self.cancel(oid)
+
+    # ------------------------------------------------------------------
+    # ExecutionClient interface
+    # ------------------------------------------------------------------
     def send(self, order: Order) -> str:  # pragma: no cover - stub
-        # Replace the print statements with real broker API calls.
+        if not self._connected:
+            self.connect()
         print(f"LIVE ORDER -> {order.symbol} {order.qty}@{order.price}")
         self._positions[order.symbol] = self._positions.get(order.symbol, 0.0) + order.qty
+        self._pending_orders[order.id] = order
+        self.obs.increment_orders_sent()
         return order.id
 
     def cancel(self, order_id: str) -> None:  # pragma: no cover - stub
         print(f"CANCEL ORDER -> {order_id}")
+        self._pending_orders.pop(order_id, None)
+        self.obs.increment_order_errors()
 
     def positions(self) -> Dict[str, float]:  # pragma: no cover - trivial
         return dict(self._positions)

--- a/tests/test_broker_execution_client.py
+++ b/tests/test_broker_execution_client.py
@@ -1,0 +1,36 @@
+import time
+
+from execution import BrokerExecutionClient, Order
+from quant_pipeline.observability import Observability
+
+
+def test_heartbeat_updates_observability():
+    obs = Observability()
+    client = BrokerExecutionClient(observability=obs, heartbeat_interval=0.1)
+    time.sleep(0.25)
+    assert obs._heartbeat_ts > 0
+    client.close()
+
+
+def test_disconnect_cancels_orders_and_reconnect(monkeypatch):
+    obs = Observability()
+    client = BrokerExecutionClient(observability=obs, heartbeat_interval=0.05)
+    order = Order("SPY", 1, price=1.0)
+    client.send(order)
+    assert order.id in client._pending_orders
+
+    state = {"called": False}
+
+    def ping_fail_once():
+        if not state["called"]:
+            state["called"] = True
+            return False
+        return True
+
+    monkeypatch.setattr(client, "_ping", ping_fail_once)
+    time.sleep(0.15)
+
+    assert order.id not in client._pending_orders
+    assert obs.order_errors_total._value.get() == 1
+    assert client._connected
+    client.close()


### PR DESCRIPTION
## Summary
- add heartbeat thread and connection checks to BrokerExecutionClient
- cancel pending orders on disconnect and automatically reconnect
- track order and connection events via Observability metrics

## Testing
- ⚠️ `pytest -q` (terminated early due to timeout)
- ✅ `pytest tests/test_broker_execution_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22ca2dda8832da8f96a8e79b7abdf