### PR TITLE
Add smart order routing and integrate with trading engine

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Optional
 
 from execution import ExecutionClient, Order
 from risk import RiskManager
+from trading import sor
 
 
 @dataclass
@@ -43,7 +44,7 @@ class TradingEngine:
         order = Order(symbol=getattr(market_data, "symbol", ""), qty=qty, price=side_price)
         if not self.risk_manager.pre_trade(order, self.execution_client.positions()):
             return None
-        order_id = self.execution_client.send(order)
+        order_id = sor.route_order(order, self.execution_client)
         self.risk_manager.post_trade(order, self.execution_client.positions())
         return order_id
 

--- a/src/trading/sor.py
+++ b/src/trading/sor.py
@@ -1,0 +1,77 @@
+"""Simple smart order router (SOR).
+
+This module exposes a :func:`route_order` helper that inspects quotes
+across multiple venues and submits the order through the venue offering
+best execution.  It expects each venue to be represented by an
+``ExecutionClient`` that optionally implements a ``quote`` method
+returning ``(price, volume)`` for a given symbol.
+
+If only a single execution client is provided, the function falls back to
+sending the order directly without routing.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from execution import ExecutionClient, Order
+
+
+def _pick_venue(order: Order, venues: Dict[str, ExecutionClient]) -> ExecutionClient:
+    """Select the best venue based on price and available volume."""
+
+    best: ExecutionClient | None = None
+    best_price: float | None = None
+    required_vol = abs(order.qty)
+
+    for client in venues.values():
+        quote_fn = getattr(client, "quote", None)
+        if quote_fn is None:
+            continue
+        price, volume = quote_fn(order.symbol)
+        if volume < required_vol:
+            continue
+        if best is None:
+            best = client
+            best_price = price
+            continue
+        if order.qty > 0:  # buy -> prefer lower price
+            if price < (best_price if best_price is not None else float("inf")):
+                best = client
+                best_price = price
+        else:  # sell -> prefer higher price
+            if price > (best_price if best_price is not None else float("-inf")):
+                best = client
+                best_price = price
+
+    if best is None:
+        # No venue had enough liquidity or quotes were unavailable; fall back
+        # to the first client in the mapping.
+        best = next(iter(venues.values()))
+    return best
+
+
+def route_order(order: Order, venues: Dict[str, ExecutionClient] | ExecutionClient) -> str:
+    """Route ``order`` to the optimal venue and return its id.
+
+    Parameters
+    ----------
+    order:
+        Order to be submitted.
+    venues:
+        Either a mapping of venue names to ``ExecutionClient`` instances or a
+        single ``ExecutionClient``.  When a mapping is provided the router will
+        attempt to query each venue for quotes via a ``quote`` method.
+
+    Returns
+    -------
+    str
+        Identifier of the submitted order.
+    """
+
+    if isinstance(venues, dict):
+        client = _pick_venue(order, venues)
+        return client.send(order)
+
+    # Fallback for single client – no routing required
+    return venues.send(order)

--- a/tests/test_sor.py
+++ b/tests/test_sor.py
@@ -1,0 +1,72 @@
+import datetime as dt
+
+from engine import TradingEngine
+from execution import ExecutionClient, Order
+from risk import RiskManager, RiskLimits
+from trading import sor
+
+
+class StubClient(ExecutionClient):
+    def __init__(self, price: float, volume: float, name: str):
+        self.price = price
+        self.volume = volume
+        self.name = name
+        self.sent: list[Order] = []
+
+    def quote(self, symbol: str):
+        return self.price, self.volume
+
+    def send(self, order: Order) -> str:
+        self.sent.append(order)
+        return f"{self.name}-{len(self.sent)}"
+
+    def cancel(self, order_id: str) -> None:
+        pass
+
+    def positions(self):
+        return {}
+
+    def clock(self):  # pragma: no cover - simple pass-through
+        return dt.datetime.now(dt.timezone.utc)
+
+
+def test_route_order_selects_by_price_and_volume():
+    order = Order(symbol="BTC", qty=10)
+    a = StubClient(price=100.0, volume=5, name="A")  # insufficient volume
+    b = StubClient(price=101.0, volume=20, name="B")
+    venues = {"A": a, "B": b}
+    oid = sor.route_order(order, venues)
+    assert oid.startswith("B-")
+    assert not a.sent
+    assert b.sent and b.sent[0] == order
+
+    sell_order = Order(symbol="BTC", qty=-5)
+    c = StubClient(price=100.0, volume=10, name="C")
+    d = StubClient(price=110.0, volume=10, name="D")
+    venues = {"C": c, "D": d}
+    oid = sor.route_order(sell_order, venues)
+    assert oid.startswith("D-")
+    assert d.sent and d.sent[0] == sell_order
+
+
+def test_trading_engine_uses_sor(monkeypatch):
+    model = type("M", (), {"predict": lambda self, _: 1.0})()
+    risk = RiskManager(RiskLimits(max_position=1000))
+    client = StubClient(price=100, volume=100, name="X")
+    engine = TradingEngine(model, lambda x: x, risk, client)
+
+    called = {}
+
+    def fake_route(order, venues):
+        called["order"] = order
+        return venues.send(order)
+
+    monkeypatch.setattr(sor, "route_order", fake_route)
+
+    class Data:
+        symbol = "BTC"
+        price = 100.0
+
+    oid = engine.on_bar(Data())
+    assert "order" in called
+    assert oid.startswith("X-")


### PR DESCRIPTION
## Summary
- add `trading.sor` module to pick the best venue using quote price/volume and forward orders through its `ExecutionClient`
- route orders via `sor.route_order` inside `TradingEngine` instead of directly calling `execution_client.send`
- cover routing logic and engine integration with unit tests

## Testing
- `pytest tests/test_sor.py -q`
- `pytest tests/test_execution_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22ca260ac832d91a70cba6f6dcd34