### PR TITLE
feat: add meta labeling filter and calibrated sizing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,3 +12,7 @@ execution:
 
 data:
   source: csv
+
+meta:
+  p_long: 0.6
+  p_short: 0.6

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -10,6 +10,9 @@ loop = DecisionLoop(
     risk,
     oms,
     obs,
+    meta_model=meta_clf,
+    p_long=0.6,
+    p_short=0.6,
     median_window=5,
     hysteresis=0.05,
 )
@@ -17,3 +20,5 @@ loop = DecisionLoop(
 
 - `median_window` applies a median filter of the given window size to the EMA output.
 - `hysteresis` adds symmetric entry/exit bands around the `threshold` to avoid rapid toggling.
+- `meta_model` provides meta-labeling probabilities; trades are only executed when
+  they exceed `p_long`/`p_short` and the calibrated probability drives sizing.


### PR DESCRIPTION
## Summary
- integrate optional meta-model to DecisionLoop
- filter trades with configurable probability thresholds
- size positions using calibrated meta probabilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b224e20914832d85d2e9f71beba0fd