### PR TITLE
Add model adapters, cross-asset and risk-parity utilities

### DIFF
--- a/src/quant_pipeline/adapters.py
+++ b/src/quant_pipeline/adapters.py
@@ -1,0 +1,85 @@
+"""Model adapters and rule-based strategies for diverse signal sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import GradientBoostingRegressor
+import torch
+from torch import nn
+
+
+class XGBAdapter:
+    """Light-weight adapter wrapping a gradient boosting regressor.
+
+    The project does not depend on the ``xgboost`` package to keep the
+    footprint small.  Instead we approximate the behaviour using
+    :class:`sklearn.ensemble.GradientBoostingRegressor` which provides a
+    compatible ``fit``/``predict`` API for tabular features.
+    """
+
+    def __init__(self, **params) -> None:
+        self.model = GradientBoostingRegressor(**params)
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self.model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.predict(X)
+
+
+class TCNAdapter(nn.Module):
+    """Very small Temporal Convolutional Network for sequence features."""
+
+    def __init__(self, input_size: int, channels: int = 8, kernel_size: int = 3) -> None:
+        super().__init__()
+        padding = (kernel_size - 1)
+        self.conv = nn.Conv1d(input_size, channels, kernel_size, padding=padding)
+        self.relu = nn.ReLU()
+        self.fc = nn.Linear(channels, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # ``x`` expected shape: (batch, seq_len, features)
+        x = x.transpose(1, 2)  # to (batch, features, seq)
+        y = self.relu(self.conv(x))
+        return self.fc(y[:, :, -1])
+
+    def fit(self, X: np.ndarray, y: np.ndarray, *, epochs: int = 10, lr: float = 1e-3) -> None:
+        self.train()
+        optim = torch.optim.Adam(self.parameters(), lr=lr)
+        loss_fn = nn.MSELoss()
+        x_t = torch.tensor(X, dtype=torch.float32)
+        y_t = torch.tensor(y, dtype=torch.float32).view(-1, 1)
+        for _ in range(epochs):
+            optim.zero_grad()
+            pred = self.forward(x_t)
+            loss = loss_fn(pred, y_t)
+            loss.backward()
+            optim.step()
+        self.eval()
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        with torch.no_grad():
+            x_t = torch.tensor(X, dtype=torch.float32)
+            pred = self.forward(x_t)
+        return pred.view(-1).numpy()
+
+
+@dataclass
+class RuleStrategy:
+    """Simple rule-based strategy using threshold on feature mean."""
+
+    threshold: float = 0.0
+
+    def predict(self, features: pd.DataFrame | np.ndarray) -> np.ndarray:
+        if isinstance(features, pd.DataFrame):
+            arr = features.to_numpy(dtype=float)
+        else:
+            arr = np.asarray(features, dtype=float)
+        signal = np.where(arr.mean(axis=1) > self.threshold, 1.0, -1.0)
+        return signal
+
+
+__all__ = ["XGBAdapter", "TCNAdapter", "RuleStrategy"]

--- a/src/quant_pipeline/cross_asset.py
+++ b/src/quant_pipeline/cross_asset.py
@@ -1,0 +1,35 @@
+"""Cross-asset relationship utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def pair_spread(df: pd.DataFrame, asset_a: str, asset_b: str) -> pd.Series:
+    """Return price spread between two assets.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Must contain columns for ``asset_a`` and ``asset_b`` prices.
+    asset_a, asset_b : str
+        Column names representing the two assets.
+    """
+
+    return df[asset_a] - df[asset_b]
+
+
+class CrossAssetSignal:
+    """Generate cross-asset signals for multiple pairs."""
+
+    def __init__(self, pairs: list[tuple[str, str]]):
+        self.pairs = pairs
+
+    def compute(self, df: pd.DataFrame) -> pd.DataFrame:
+        signals = {}
+        for a, b in self.pairs:
+            signals[f"{a}_{b}_spread"] = pair_spread(df, a, b)
+        return pd.DataFrame(signals, index=df.index)
+
+
+__all__ = ["pair_spread", "CrossAssetSignal"]

--- a/src/quant_pipeline/ensemble.py
+++ b/src/quant_pipeline/ensemble.py
@@ -89,4 +89,26 @@ class SignalEnsemble:
         return blended
 
 
-__all__ = ["SignalEnsemble"]
+class MultiHorizonEnsemble:
+    """Blend signals across multiple forecast horizons."""
+
+    def __init__(self, ensembles: Mapping[str, SignalEnsemble]) -> None:
+        self.ensembles = dict(ensembles)
+
+    def blend(
+        self,
+        signals: Mapping[str, Mapping[str, np.ndarray | float]],
+        *,
+        weights: Mapping[str, Mapping[str, float]] | None = None,
+    ) -> Dict[str, np.ndarray]:
+        """Blend signals per horizon using corresponding ensembles."""
+
+        blended: Dict[str, np.ndarray] = {}
+        for horizon, sig in signals.items():
+            ens = self.ensembles[horizon]
+            w = weights.get(horizon) if weights is not None else None
+            blended[horizon] = ens.blend(sig, weights=w)
+        return blended
+
+
+__all__ = ["SignalEnsemble", "MultiHorizonEnsemble"]

--- a/src/quant_pipeline/macro_factors.py
+++ b/src/quant_pipeline/macro_factors.py
@@ -1,0 +1,23 @@
+"""Macro factor calculations such as volatility spreads and carry."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def vol_spread(implied: pd.Series, realized: pd.Series) -> pd.Series:
+    """Difference between implied and realized volatility."""
+    return implied - realized
+
+
+def carry(spot: pd.Series, future: pd.Series, days: int) -> pd.Series:
+    """Compute simple carry given spot and future prices."""
+    return (future - spot) / days
+
+
+def inflation_adjusted_rate(rate: pd.Series, inflation: pd.Series) -> pd.Series:
+    """Return real rate after inflation."""
+    return rate - inflation
+
+
+__all__ = ["vol_spread", "carry", "inflation_adjusted_rate"]

--- a/src/quant_pipeline/risk_parity.py
+++ b/src/quant_pipeline/risk_parity.py
@@ -1,0 +1,30 @@
+"""Risk parity and equal-risk-contribution utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def risk_parity_weights(cov: pd.DataFrame) -> pd.Series:
+    """Approximate risk parity weights from a covariance matrix."""
+
+    inv_vol = 1.0 / np.sqrt(np.diag(cov))
+    w = inv_vol / inv_vol.sum()
+    return pd.Series(w, index=cov.columns)
+
+
+def rolling_risk_parity(returns: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Compute rolling risk parity weights over ``window`` observations."""
+
+    weights = []
+    index = []
+    for i in range(window, len(returns) + 1):
+        cov = returns.iloc[i - window : i].cov()
+        w = risk_parity_weights(cov)
+        weights.append(w)
+        index.append(returns.index[i - 1])
+    return pd.DataFrame(weights, index=index)
+
+
+__all__ = ["risk_parity_weights", "rolling_risk_parity"]

--- a/src/quant_pipeline/signal_store.py
+++ b/src/quant_pipeline/signal_store.py
@@ -1,0 +1,71 @@
+"""SQLite-backed persistence for model signals and weights."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Tuple
+
+
+class SignalStore:
+    """Persist signals and weights by strategy/symbol/horizon."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.conn = sqlite3.connect(db_path)
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS signals(
+                ts INTEGER,
+                strategy TEXT,
+                symbol TEXT,
+                horizon TEXT,
+                signal REAL,
+                weight REAL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def save(
+        self,
+        *,
+        ts: int,
+        strategy: str,
+        symbol: str,
+        horizon: str,
+        signal: float,
+        weight: float,
+    ) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO signals(ts, strategy, symbol, horizon, signal, weight) VALUES(?,?,?,?,?,?)",
+            (ts, strategy, symbol, horizon, signal, weight),
+        )
+        self.conn.commit()
+
+    def load(
+        self,
+        *,
+        strategy: str,
+        symbol: str,
+        horizon: str,
+        start: int,
+        end: int,
+    ) -> list[Tuple[int, float, float]]:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            SELECT ts, signal, weight FROM signals
+            WHERE strategy=? AND symbol=? AND horizon=? AND ts BETWEEN ? AND ?
+            ORDER BY ts
+            """,
+            (strategy, symbol, horizon, start, end),
+        )
+        return [(int(ts), float(sig), float(w)) for ts, sig, w in cur.fetchall()]
+
+
+__all__ = ["SignalStore"]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pandas as pd
+
+from quant_pipeline.adapters import XGBAdapter, TCNAdapter, RuleStrategy
+
+
+def test_xgb_adapter_basic():
+    X = np.arange(10).reshape(-1, 1)
+    y = np.arange(10)
+    model = XGBAdapter()
+    model.fit(X, y)
+    pred = model.predict(X[:2])
+    assert pred.shape == (2,)
+
+
+def test_tcn_adapter_basic():
+    X = np.random.randn(20, 5, 1)
+    y = np.random.randn(20)
+    model = TCNAdapter(input_size=1)
+    model.fit(X, y, epochs=1)
+    pred = model.predict(X[:2])
+    assert pred.shape == (2,)
+
+
+def test_rule_strategy():
+    df = pd.DataFrame({"a": [-1, 2, -3, 4]})
+    strat = RuleStrategy(threshold=0.0)
+    sig = strat.predict(df)
+    assert (sig == np.array([-1, 1, -1, 1])).all()

--- a/tests/test_multi_horizon_ensemble.py
+++ b/tests/test_multi_horizon_ensemble.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from quant_pipeline.ensemble import SignalEnsemble, MultiHorizonEnsemble
+
+
+class Dummy:
+    def __init__(self, value):
+        self.value = value
+
+    def predict(self, X):
+        return np.full(len(X), self.value)
+
+
+def test_multi_horizon_blend():
+    ens_short = SignalEnsemble({"m1": Dummy(0.1), "m2": Dummy(-0.2)})
+    ens_long = SignalEnsemble({"m1": Dummy(0.3), "m2": Dummy(0.4)})
+    mh = MultiHorizonEnsemble({"h1": ens_short, "h5": ens_long})
+    signals = {"h1": {"m1": 0.1, "m2": -0.2}, "h5": {"m1": 0.3, "m2": 0.4}}
+    weights = {"h1": {"m1": 0.5, "m2": 0.5}, "h5": {"m1": 0.7, "m2": 0.3}}
+    blended = mh.blend(signals, weights=weights)
+    assert set(blended.keys()) == {"h1", "h5"}
+    assert np.isclose(blended["h1"], -0.05)
+    assert np.isclose(blended["h5"], 0.33)

--- a/tests/test_risk_parity.py
+++ b/tests/test_risk_parity.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from quant_pipeline.risk_parity import risk_parity_weights, rolling_risk_parity
+
+
+def test_risk_parity_weights_basic():
+    cov = pd.DataFrame([[0.04, 0.0], [0.0, 0.09]], columns=["A", "B"], index=["A", "B"])
+    w = risk_parity_weights(cov)
+    assert np.allclose(w.values, [0.6, 0.4], atol=1e-6)
+
+
+def test_rolling_risk_parity():
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(20, 2))
+    rets = pd.DataFrame(data, columns=["A", "B"])
+    weights = rolling_risk_parity(rets, window=5)
+    assert weights.shape[0] == 16
+    assert list(weights.columns) == ["A", "B"]
+

--- a/tests/test_signal_store.py
+++ b/tests/test_signal_store.py
@@ -1,0 +1,9 @@
+from quant_pipeline.signal_store import SignalStore
+
+
+def test_signal_store_roundtrip(tmp_path):
+    db = tmp_path / "signals.db"
+    store = SignalStore(db)
+    store.save(ts=1, strategy="s1", symbol="BTC", horizon="h1", signal=0.5, weight=0.2)
+    rows = store.load(strategy="s1", symbol="BTC", horizon="h1", start=0, end=10)
+    assert rows == [(1, 0.5, 0.2)]


### PR DESCRIPTION
## Summary
- add XGB, TCN and rule-based signal adapters
- support cross-asset and macro factor signals
- introduce multi-horizon ensembles, risk-parity weights and SQLite signal store

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b235e12ba4832da276c274d32a701f